### PR TITLE
parse_opt: use right type in printf

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -191,11 +191,11 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 	case 'x':
 		idx = strtol(arg, NULL, 10);
 		if ((idx == LONG_MAX) || (idx > ENT_MAX)) {
-			printf("exclude index is out of range: %d\n", idx);
+			printf("exclude index is out of range: %ld\n", idx);
 			return -ERANGE;
 		}
 		entropy_sources[idx].disabled = true;
-		printf("Disabling %d: %s\n", idx, entropy_sources[idx].rng_name);
+		printf("Disabling %ld: %s\n", idx, entropy_sources[idx].rng_name);
 		break;
 	case 'l':
 		arguments->list = true;


### PR DESCRIPTION
Previous error:

rngd.c: In function ‘parse_opt’:
rngd.c:195:44: warning: format ‘%d’ expects argument of type ‘int’, but
argument 2 has type ‘long int’ [-Wformat=]
    printf("exclude index is out of range: %d\n", idx);
                                            ^
rngd.c:199:22: warning: format ‘%d’ expects argument of type ‘int’, but
argument 2 has type ‘long int’ [-Wformat=]
   printf("Disabling %d: %s\n", idx, entropy_sources[idx].rng_name);
                      ^