### PR TITLE
Add forward declaration of init_darn_entropy_source to enable compilation

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -51,6 +51,7 @@
 #include "fips.h"
 #include "exits.h"
 #include "rngd_entsource.h"
+#include "rngd_darn.h"
 #include "rngd_linux.h"
 
 /*

--- a/rngd_darn.h
+++ b/rngd_darn.h
@@ -1,0 +1,28 @@
+/*
+ * rngd_darn.h -- Entropy source and conditioning
+ *
+ * Copyright (c) 2017, Neil Horman 
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
+ */
+
+#ifndef RNGD_DARN__H
+#define RNGD_DARN__H
+
+#include "rng-tools-config.h"
+
+extern int init_darn_entropy_source(struct rng *);
+
+#endif


### PR DESCRIPTION
wouldn't compile otherwise

gcc -DHAVE_CONFIG_H -I.     -g -O2 -MT rngd_darn.o -MD -MP -MF .deps/rngd_darn.Tpo -c -o rngd_darn.o rngd_darn.c
rngd.c:170:21: error: ‘init_darn_entropy_source’ undeclared here (not in a function)
   .init           = init_darn_entropy_source,
                     ^~~~~~~~~~~~~~~~~~~~~~~~
