### PR TITLE
Fix the default '--fill-watermark' value in the man page

### DIFF
--- a/rngd.8.in
+++ b/rngd.8.in
@@ -82,7 +82,9 @@ Number of bits to consider random when adding entropy. 1<=e<=8
 .TP
 \fB\-W\fI n\fR, \fB\-\-fill\-watermark=\fInnn\fR
 Once we start doing it, feed entropy to \fIrandom-device\fR until at least
-\fIfill-watermark\fR bits of entropy are available in its entropy pool (default: 2048).
+\fIfill-watermark\fR bits of entropy are available in its entropy pool.
+By default, this value is set to 75% of the entropy pool size or 2048 bits
+if the entropy pool size couldn't be determined.
 Setting this too high will cause \fIrngd\fR to dominate the contents of the
 entropy pool.  Low values will hurt system performance during entropy 
 starves.  Do not set \fIfill-watermark\fR above the size of the


### PR DESCRIPTION
According to rngd man page, the default value for the
'--fill-watermark' option is 2048 bits. However, upon examining
default_watermark() function in rngd_linux.c, it can be seen that this
is true for systems where poolsize cannot be obtained. In linux, the
pool size can be obtained by reading
'/proc/sys/kernel/random/poolsize'. If rngd is capable of reading the
proc entry, as it should be, then it sets the --fill-watermark value
to be 75% of the total pool size, typically 3072 bits.

Bug: https://bugs.gentoo.org/555094