### PR TITLE
Check for signals in update_kernel_random()

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -285,6 +285,8 @@ static int update_kernel_random(int random_step,
 
 	for (p = buf; p + random_step <= &buf[FIPS_RNG_BUFFER_SIZE];
 		 p += random_step) {
+		if (!server_running)
+			return 0;
 		random_add_entropy(p, random_step);
 		random_sleep();
 	}
@@ -308,10 +310,10 @@ static void do_loop(int random_step)
 			int rc;
 			iter = &entropy_sources[i];
 
+		retry_same:
 			if (!server_running)
 				return;
 
-		retry_same:
 			if (iter->disabled)
 				continue;	/* failed, no work */
 


### PR DESCRIPTION
When running as a daemon, a signal handler is installed to catch
SIGINT/SIGTERM. This handler sets a flag that's tested in the main
loop. However, rngd loops in update_kernel_random() as well, where
the flag was not tested.

This patch adds the check to update_kernel_random() so that the
daemon exits properly after receiving a SIGINT/SIGTERM signal.

https://sourceforge.net/p/gkernel/bugs/135/

Have been carrying this patch, taken from that sourceforge ticket, for a few years. It fixes rngd getting stuck on system shutdown until init/systemd kills it after the timeout.