### PR TITLE
Addition of CPU Jitter RNG noise source

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,11 +11,18 @@ noinst_LIBRARIES = librngd.a
 
 rngd_SOURCES	= rngd.h rngd.c	rngd_entsource.h rngd_entsource.c	\
 		  rngd_linux.h rngd_linux.c util.c
+rngd_LDADD	=
+rngd_CFLAGS	=
 
 if NISTBEACON
 rngd_SOURCES	+= rngd_nistbeacon.c
 endif
  
+if JENT
+rngd_SOURCES	+= rngd_jent.c libjitterentropy.a
+rngd_LDADD	+= $(libjitterentropy_prefix)/libjitterentropy.a
+endif
+
 if RDRAND
 rngd_SOURCES	+= rngd_rdrand.c rdrand_asm.S
 endif
@@ -24,9 +31,9 @@ if DARN
 rngd_SOURCES	+= rngd_darn.c
 endif
 
-rngd_LDADD	= librngd.a -lsysfs ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS}
+rngd_LDADD	+= librngd.a -lsysfs ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS}
 
-rngd_CFLAGS	= ${libxml2_CFLAGS} ${openssl_CFLAGS}
+rngd_CFLAGS	+= ${libxml2_CFLAGS} ${openssl_CFLAGS}
 
 rngtest_SOURCES	= exits.h stats.h stats.c rngtest.c
 rngtest_LDADD	= librngd.a

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,12 @@ AC_ARG_WITH([nistbeacon],
 	[],
 	[with_nistbeacon=check]
 )
+AC_ARG_WITH([jent],
+	AS_HELP_STRING([--without-jent],
+		[Disable CPU Jitter RNG support. ]),
+	[],
+	[with_jent=check]
+)
 
 dnl Make sure anyone changing configure.ac/Makefile.am has a clue
 AM_MAINTAINER_MODE
@@ -65,6 +71,24 @@ AS_IF(
 )
 
 AM_CONDITIONAL([NISTBEACON], [test "x$with_nistbeacon" != "xno"])
+
+AS_IF(
+	[ test "x$with_jent" != "xno"],
+	[
+		AC_DEFINE([HAVE_JENT],1,[Enable JENT])
+	]
+)
+
+AM_CONDITIONAL([JENT], [test "x$with_jent" != "xno"])
+libjitterentropy_prefix="."
+AC_ARG_WITH(libjitterentropy-prefix,
+  AC_HELP_STRING([--with-libjitterentropy-prefix=PFX],
+    [prefix where static CPU Jitter RNG library is installed (optional)]),
+    [libjitterentropy_prefix="$withval"])
+if test x"${libjitterentropy_prefix}" != x ; then
+  CPPFLAGS+="-I${libjitterentropy_prefix}"
+  AC_SUBST(libjitterentropy_prefix)
+fi
 
 dnl Checks for header files.
 dnl AC_HEADER_STDC

--- a/rngd.c
+++ b/rngd.c
@@ -136,6 +136,7 @@ static enum {
 	ENT_RDRAND,
 	ENT_DARN,
 	ENT_NISTBEACON,
+	ENT_JENT,
 	ENT_MAX
 } entropy_indexes;
 
@@ -184,6 +185,16 @@ static struct rng entropy_sources[ENT_MAX] = {
 		.init		= init_nist_entropy_source,
 #endif
 		.disabled	= true,
+	},
+	{
+		.rng_name	= "CPU Jitter RNG",
+		.rng_fd		= -1,
+#ifdef HAVE_JENT
+		.xread		= xread_jent,
+		.init		= init_jent_entropy_source,
+#else
+		.disabled	= true,
+#endif
 	},
 };
 

--- a/rngd_entsource.h
+++ b/rngd_entsource.h
@@ -45,6 +45,9 @@ extern int init_darn_entropy_source(struct rng *);
 #ifdef HAVE_NISTBEACON
 extern int init_nist_entropy_source(struct rng *);
 #endif
+#ifdef HAVE_JENT
+extern int init_jent_entropy_source(struct rng *);
+#endif
 
 
 extern int init_tpm_entropy_source(struct rng *);
@@ -62,5 +65,9 @@ extern int xread_darn(void *buf, size_t size, struct rng *ent_src);
 extern int xread_nist(void *buf, size_t size, struct rng *ent_src);
 
 extern int xread_tpm(void *buf, size_t size, struct rng *ent_src);
+
+#ifdef HAVE_JENT
+extern int xread_jent(void *buf, size_t size, struct rng *ent_src);
+#endif
 
 #endif /* RNGD_ENTSOURCE__H */

--- a/rngd_jent.c
+++ b/rngd_jent.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018, Stephan Mueller
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <jitterentropy.h>
+
+#include "rngd.h"
+#include "rngd_entsource.h"
+
+#define JENT_OSR	1
+
+static struct rand_data *jent = NULL;
+
+int xread_jent(void *buf, size_t size, struct rng *ent_src)
+{
+printf("JENT %u\n", size);
+	int ret = jent_read_entropy(jent, (char *)buf, size);
+
+	(void)ent_src;
+
+	if (ret < 0)
+		return ret;
+	return 0;
+}
+
+int init_jent_entropy_source(struct rng *ent_src)
+{
+	int rc;
+
+	(void)ent_src;
+	rc = jent_entropy_init();
+	if (rc) {
+		message(LOG_DAEMON|LOG_WARNING, "WARNING: CPU Jitter RNG "
+						"non-operational as CPU does "
+						"not provide expected "
+						"capabilities\n");
+	}
+
+	jent = jent_entropy_collector_alloc(JENT_OSR, 0);
+	if (!jent)
+		return -ENOMEM;
+
+	return rc;
+}


### PR DESCRIPTION
The CPU Jitter RNG noise source is added as a new generic noise source.
It requires the static CPU Jitter RNG library that can be obtained from
[1]. The static library can be pointed to using the configure option of
--with-libjitterentropy-prefix.

The CPU Jitter RNG noise source is extensively discussed at [1].

[1] http://www.chronox.de/jent.html

Signed-off-by: Stephan Mueller <smueller@chronox.de>