### PR TITLE
Add Jitter entropy source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jitterentropy-library"]
+	path = jitterentropy-library
+	url = https://github.com/smuellerDD/jitterentropy-library.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       libssl-dev
       libcurl3-dev
 
-script: ./autogen.sh && ./configure && make && make check
+script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure && make && make check
 
 after_script: 
         - make check || (cat tests/rngtesturandom.sh.log && cat tests/rngtestzero.sh.log && cat ./tests/test-suite.log)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,13 @@
 ##
 ## Toplevel Makefile.am for rng-tools
 ##
+if JITTER
+ JSUBDIR = jitterentropy-library
+ JSUBLIB = ./jitterentropy-library/libjitterentropy.a
+ AM_CPPFLAGS = -I./jitterentropy-library
+endif
 
-SUBDIRS		= contrib tests
+SUBDIRS		= contrib tests $(JSUBDIR) 
 
 sbin_PROGRAMS	 = rngd
 bin_PROGRAMS	 = rngtest
@@ -24,7 +29,7 @@ if DARN
 rngd_SOURCES	+= rngd_darn.c
 endif
 
-rngd_LDADD	= librngd.a -lsysfs ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS}
+rngd_LDADD	= librngd.a -lsysfs $(JSUBLIB) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS}
 
 rngd_CFLAGS	= ${libxml2_CFLAGS} ${openssl_CFLAGS}
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,10 @@ if DARN
 rngd_SOURCES	+= rngd_darn.c
 endif
 
+if JITTER
+rngd_SOURCES	+= rngd_jitter.c
+endif
+
 rngd_LDADD	= librngd.a -lsysfs $(JSUBLIB) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS}
 
 rngd_CFLAGS	= ${libxml2_CFLAGS} ${openssl_CFLAGS}

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,9 @@ AS_IF([test $host_cpu = x86_64 -o $host_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,
 AM_CONDITIONAL([DARN], [test $host_cpu = powerpc64le])
 AS_IF([test $host_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
+AM_CONDITIONAL([JITTER], [test -d jitterentropy-library])
+AS_IF([test -d jitterentropy-library], [AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],[])
+
 AS_IF(
 	[ test "x$with_nistbeacon" != "xno"],
 	[

--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,8 @@ AS_IF([test $host_cpu = x86_64 -o $host_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,
 AM_CONDITIONAL([DARN], [test $host_cpu = powerpc64le])
 AS_IF([test $host_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
-AM_CONDITIONAL([JITTER], [test -d jitterentropy-library])
-AS_IF([test -d jitterentropy-library], [AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],[])
+AM_CONDITIONAL([JITTER], [test -f jitterentropy-library/Makefile])
+AS_IF([test -f jitterentropy-library/Makefile], [AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],[AC_MSG_NOTICE([Disabling JITTER entropy source])])
 
 AS_IF(
 	[ test "x$with_nistbeacon" != "xno"],

--- a/rngd.c
+++ b/rngd.c
@@ -310,18 +310,18 @@ static void do_loop(int random_step)
 	unsigned char buf[FIPS_RNG_BUFFER_SIZE];
 	int retval = 0;
 	int no_work = 0;
-	int i;
+	static int i = 0;
 
 	while (no_work < 100) {
 		struct rng *iter;
 		bool work_done;
 
 		work_done = false;
-		for (i=0; i < ENT_MAX; i++)
+		for (;i=(++i % ENT_MAX);)
 		{
 			int rc;
+			printf("I is %d\n", i);
 			iter = &entropy_sources[i];
-
 		retry_same:
 			if (!server_running)
 				return;

--- a/rngd.c
+++ b/rngd.c
@@ -404,9 +404,9 @@ int main(int argc, char **argv)
 			}
 		if (!found)
 			printf("None");
-		printf("\nInitalizing available sources\n");
 		msg_squash = true;
-	}
+	} else
+		printf("\nInitalizing available sources\n");
 
 	/* Init entropy sources */
 	
@@ -428,7 +428,7 @@ int main(int argc, char **argv)
 	if (arguments->list) {
 		int rc = 1;
 		msg_squash = false;
-		printf("Available entropy sources:\n");
+		printf("Available and enabled entropy sources:\n");
 		for (i=0; i < ENT_MAX; i++) 
 			if (entropy_sources[i].init && entropy_sources[i].disabled == false) {
 				rc = 1;

--- a/rngd.h
+++ b/rngd.h
@@ -68,6 +68,7 @@ struct rng {
 
 	int (*xread) (void *buf, size_t size, struct rng *ent_src);
 	int (*init) (struct rng *ent_src);
+	void (*close) (struct rng *end_src);
 	fips_ctx_t *fipsctx;
 
 	struct rng *next;

--- a/rngd_entsource.h
+++ b/rngd_entsource.h
@@ -45,6 +45,10 @@ extern int init_darn_entropy_source(struct rng *);
 #ifdef HAVE_NISTBEACON
 extern int init_nist_entropy_source(struct rng *);
 #endif
+#ifdef HAVE_JITTER
+extern int init_jitter_entropy_source(struct rng *);
+extern void close_jitter_entropy_source(struct rng *);
+#endif
 
 
 extern int init_tpm_entropy_source(struct rng *);
@@ -57,6 +61,10 @@ extern int xread_drng(void *buf, size_t size, struct rng *ent_src);
 
 #ifdef HAVE_DARN
 extern int xread_darn(void *buf, size_t size, struct rng *ent_src);
+#endif
+
+#ifdef HAVE_JITTER
+extern int xread_jitter(void *buf, size_t size, struct rng *ent_src);
 #endif
 
 extern int xread_nist(void *buf, size_t size, struct rng *ent_src);

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, Neil Horman 
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#ifndef HAVE_CONFIG_H
+#error Invalid or missing autoconf build environment
+#endif
+
+#include "rng-tools-config.h"
+
+#include <jitterentropy.h>
+
+#include "rngd.h"
+#include "fips.h"
+#include "exits.h"
+#include "rngd_entsource.h"
+
+struct rand_data *ec = NULL;
+
+int xread_jitter(void *buf, size_t size, struct rng *ent_src)
+{
+	size_t ret;
+	size_t total = 0;
+	size_t len = size;
+	while (total != size) {
+		ret = jent_read_entropy(ec, buf, len);
+		if (ret < 0)
+			return 1;
+		buf += size;
+		total+=size;
+		len-=ret;
+	}
+	return 0;
+}
+
+/*
+ * Init JITTER
+ */
+int init_jitter_entropy_source(struct rng *ent_src)
+{
+	int ret = jent_entropy_init();
+	if(ret) {
+		message(LOG_DAEMON|LOG_WARNING, "JITTER rng fails with code %d\n", ret);
+		return 1;
+	}
+
+	ec = jent_entropy_collector_alloc(1, 0);
+	if (!ec) {
+		message(LOG_DAEMON|LOG_WARNING, "JITTER RNG COULD NOT BE ALLOCATED\n");
+		return 1;
+	}
+	
+	message(LOG_DAEMON|LOG_INFO, "Enabling JITTER rng support\n");
+	return 0;
+}
+
+void close_jitter_entropy_source(struct rng *ent_src)
+{
+	if (ec) {
+		jent_entropy_collector_free(ec);
+		ec = NULL;
+	}
+	return;
+}
+

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -36,15 +36,10 @@ struct rand_data *ec = NULL;
 int xread_jitter(void *buf, size_t size, struct rng *ent_src)
 {
 	size_t ret;
-	size_t total = 0;
-	size_t len = size;
-	while (total != size) {
-		ret = jent_read_entropy(ec, buf, len);
-		if (ret < 0)
-			return 1;
-		buf += size;
-		total+=size;
-		len-=ret;
+	ret = jent_read_entropy(ec, buf, size);
+	if (ret < 0) {
+		message(LOG_DAEMON|LOG_DEBUG, "JITTER rng fails with code %d\n", ret);
+		return 1;
 	}
 	return 0;
 }

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -31,7 +31,7 @@
 #include "exits.h"
 #include "rngd_entsource.h"
 
-struct rand_data *ec = NULL;
+static struct rand_data *ec = NULL;
 
 int xread_jitter(void *buf, size_t size, struct rng *ent_src)
 {


### PR DESCRIPTION
The CPU Jitter RNG noise source is added as a new generic noise source.
It requires the static CPU Jitter RNG library that can be obtained from
[1]. The static library can be pointed to using the configure option of
--with-libjitterentropy-prefix.

The CPU Jitter RNG noise source is extensively discussed at [1].

[1] http://www.chronox.de/jent.html

