### PR TITLE
Catch negative error codes in xread_jitter

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -35,8 +35,7 @@ static struct rand_data *ec = NULL;
 
 int xread_jitter(void *buf, size_t size, struct rng *ent_src)
 {
-	size_t ret;
-	ret = jent_read_entropy(ec, buf, size);
+	ssize_t ret = jent_read_entropy(ec, buf, size);
 	if (ret < 0) {
 		message(LOG_DAEMON|LOG_DEBUG, "JITTER rng fails with code %d\n", ret);
 		return 1;


### PR DESCRIPTION
The jent_read_entropy function returns negative error codes. Thus, the
ret variable must be signed.

Signed-off-by: Stephan Mueller <smueller@chronox.de>