### PR TITLE
rngd.c: fixed main loop logic, and a couple of off-by-one errors

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -308,13 +308,12 @@ static int update_kernel_random(int random_step,
 static void do_loop(int random_step)
 {
 	unsigned char buf[FIPS_RNG_BUFFER_SIZE];
-	int retval = 0;
-	int no_work = 0;
-	int i = 0;
+	int no_work;
+	bool work_done;
 
-	while (no_work < 100) {
+	for (no_work = 0; no_work < 100; no_work = (work_done ? 0 : no_work+1)) {
 		struct rng *iter;
-		bool work_done;
+		int i, retval;
 
 		work_done = false;
 		for (i = 0; i < ENT_MAX; ++i)
@@ -361,11 +360,6 @@ static void do_loop(int random_step)
 				iter->disabled = true;
 			}
 		}
-
-		if (!work_done)
-			no_work++;
-		else
-			no_work = 0;
 	}
 
 	if (!arguments->quiet)

--- a/rngd.c
+++ b/rngd.c
@@ -317,16 +317,11 @@ static void do_loop(int random_step)
 		bool work_done;
 
 		work_done = false;
-		for (;;)
+		for (i = 0; i < ENT_MAX; ++i)
 		{
 			int rc;
-			if (i >= ENT_MAX) {
-				i = 0;
-				break;
-			}
 			/*printf("I is %d\n", i);*/
 			iter = &entropy_sources[i];
-			++i;
 		retry_same:
 			if (!server_running)
 				return;
@@ -349,14 +344,17 @@ static void do_loop(int random_step)
 						iter->failures--;
 					iter->success = 0;
 				}
-				break;	/* succeeded, work done */
+				/* succeeded */
+				continue;
 			}
 
 			iter->failures++;
 			if (iter->failures <= MAX_RNG_FAILURES/4) {
 				/* FIPS tests have false positives */
 				goto retry_same;
-			} else if (iter->failures >= MAX_RNG_FAILURES && !ignorefail) {
+			}
+
+			if (iter->failures >= MAX_RNG_FAILURES && !ignorefail) {
 				if (!arguments->quiet)
 					message(LOG_DAEMON|LOG_ERR,
 					"too many FIPS failures, disabling entropy source\n");

--- a/rngd.c
+++ b/rngd.c
@@ -215,7 +215,7 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 		break;
 	case 'x':
 		idx = strtol(arg, NULL, 10);
-		if ((idx == LONG_MAX) || (idx > ENT_MAX)) {
+		if ((idx == LONG_MAX) || (idx >= ENT_MAX)) {
 			printf("exclude index is out of range: %lu\n", idx);
 			return -ERANGE;
 		}
@@ -224,7 +224,7 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 		break;
 	case 'n':
 		idx = strtol(arg, NULL, 10);
-		if ((idx == LONG_MAX) || (idx > ENT_MAX)) {
+		if ((idx == LONG_MAX) || (idx >= ENT_MAX)) {
 			printf("enable index is out of range: %lu\n", idx);
 			return -ERANGE;
 		}
@@ -310,18 +310,23 @@ static void do_loop(int random_step)
 	unsigned char buf[FIPS_RNG_BUFFER_SIZE];
 	int retval = 0;
 	int no_work = 0;
-	static int i = 0;
+	int i = 0;
 
 	while (no_work < 100) {
 		struct rng *iter;
 		bool work_done;
 
 		work_done = false;
-		for (;i=(++i % ENT_MAX);)
+		for (;;)
 		{
 			int rc;
-			printf("I is %d\n", i);
+			if (i >= ENT_MAX) {
+				i = 0;
+				break;
+			}
+			/*printf("I is %d\n", i);*/
 			iter = &entropy_sources[i];
+			++i;
 		retry_same:
 			if (!server_running)
 				return;
@@ -361,6 +366,8 @@ static void do_loop(int random_step)
 
 		if (!work_done)
 			no_work++;
+		else
+			no_work = 0;
 	}
 
 	if (!arguments->quiet)


### PR DESCRIPTION
This fixes a critical error in "do_loop" which prevented entropy source 0 (/dev/hwrng) from ever being used.

It also fixes a couple of off-by-one errors, and makes do_loop function more like it was intended (I think).