### PR TITLE
Accellerate jitter with multithreading

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,9 +33,10 @@ if JITTER
 rngd_SOURCES	+= rngd_jitter.c
 endif
 
-rngd_LDADD	= librngd.a -lsysfs $(JSUBLIB) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS}
+rngd_LDADD	= librngd.a -lsysfs $(JSUBLIB) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
 
-rngd_CFLAGS	= ${libxml2_CFLAGS} ${openssl_CFLAGS}
+rngd_CFLAGS	= ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
+rngd_LDFLAGS	= $(PTHREAD_CFLAGS)
 
 rngtest_SOURCES	= exits.h stats.h stats.c rngtest.c
 rngtest_LDADD	= librngd.a

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_PREREQ(2.52)
 AC_CONFIG_SRCDIR([rngd.c])
 AM_INIT_AUTOMAKE([gnu])
 AC_CONFIG_HEADERS([rng-tools-config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 
 dnl Parse options
 
@@ -47,6 +48,8 @@ AC_PROG_CC
 AC_PROG_RANLIB
 AC_PROG_GCC_TRADITIONAL
 AC_CANONICAL_HOST
+
+AX_PTHREAD
 
 AM_CONDITIONAL([RDRAND], [test $host_cpu = x86_64 -o $host_cpu = i686])
 AS_IF([test $host_cpu = x86_64 -o $host_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,[Enable RDRAND])],[])

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,0 +1,485 @@
+# ===========================================================================
+#        https://www.gnu.org/software/autoconf-archive/ax_pthread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
+#
+# DESCRIPTION
+#
+#   This macro figures out how to build C programs using POSIX threads. It
+#   sets the PTHREAD_LIBS output variable to the threads library and linker
+#   flags, and the PTHREAD_CFLAGS output variable to any special C compiler
+#   flags that are needed. (The user can also force certain compiler
+#   flags/libs to be tested by setting these environment variables.)
+#
+#   Also sets PTHREAD_CC to any special C compiler that is needed for
+#   multi-threaded programs (defaults to the value of CC otherwise). (This
+#   is necessary on AIX to use the special cc_r compiler alias.)
+#
+#   NOTE: You are assumed to not only compile your program with these flags,
+#   but also to link with them as well. For example, you might link with
+#   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#
+#   If you are only building threaded programs, you may wish to use these
+#   variables in your default LIBS, CFLAGS, and CC:
+#
+#     LIBS="$PTHREAD_LIBS $LIBS"
+#     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CC="$PTHREAD_CC"
+#
+#   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
+#   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
+#   that name (e.g. PTHREAD_CREATE_UNDETACHED on AIX).
+#
+#   Also HAVE_PTHREAD_PRIO_INHERIT is defined if pthread is found and the
+#   PTHREAD_PRIO_INHERIT symbol is defined when compiling with
+#   PTHREAD_CFLAGS.
+#
+#   ACTION-IF-FOUND is a list of shell commands to run if a threads library
+#   is found, and ACTION-IF-NOT-FOUND is a list of commands to run it if it
+#   is not found. If ACTION-IF-FOUND is not specified, the default action
+#   will define HAVE_PTHREAD.
+#
+#   Please let the authors know if this macro fails on any platform, or if
+#   you have any other suggestions or comments. This macro was based on work
+#   by SGJ on autoconf scripts for FFTW (http://www.fftw.org/) (with help
+#   from M. Frigo), as well as ac_pthread and hb_pthread macros posted by
+#   Alejandro Forero Cuervo to the autoconf macro repository. We are also
+#   grateful for the helpful feedback of numerous users.
+#
+#   Updated for Autoconf 2.68 by Daniel Richard G.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 24
+
+AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
+AC_DEFUN([AX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_REQUIRE([AC_PROG_CC])
+AC_REQUIRE([AC_PROG_SED])
+AC_LANG_PUSH([C])
+ax_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on Tru64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
+        ax_pthread_save_CC="$CC"
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test "x$ax_pthread_ok" = "xno"; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        CC="$ax_pthread_save_CC"
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try.  Items starting with a "-" are
+# C compiler flags, and other items are library names, except for "none"
+# which indicates that we try without any flags at all, and "pthread-config"
+# which is a program returning the flags for the Pth emulation library.
+
+ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads), Tru64
+#           (Note: HP C rejects this with "bad form for `-t' option")
+# -pthreads: Solaris/gcc (Note: HP C also rejects)
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads and
+#      -D_REENTRANT too), HP C (must be checked before -lpthread, which
+#      is present but should not be used directly; and before -mthreads,
+#      because the compiler interprets this as "-mt" + "-hreads")
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case $host_os in
+
+        freebsd*)
+
+        # -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+        # lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+
+        ax_pthread_flags="-kthread lthread $ax_pthread_flags"
+        ;;
+
+        hpux*)
+
+        # From the cc(1) man page: "[-mt] Sets various -D flags to enable
+        # multi-threading and also sets -lpthread."
+
+        ax_pthread_flags="-mt -pthread pthread $ax_pthread_flags"
+        ;;
+
+        openedition*)
+
+        # IBM z/OS requires a feature-test macro to be defined in order to
+        # enable POSIX threads at all, so give the user a hint if this is
+        # not set. (We don't define these ourselves, as they can affect
+        # other portions of the system API in unpredictable ways.)
+
+        AC_EGREP_CPP([AX_PTHREAD_ZOS_MISSING],
+            [
+#            if !defined(_OPEN_THREADS) && !defined(_UNIX03_THREADS)
+             AX_PTHREAD_ZOS_MISSING
+#            endif
+            ],
+            [AC_MSG_WARN([IBM z/OS requires -D_OPEN_THREADS or -D_UNIX03_THREADS to enable pthreads support.])])
+        ;;
+
+        solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed. (N.B.: The stubs are missing
+        # pthread_cleanup_push, or rather a function called by this macro,
+        # so we could check for that, but who knows whether they'll stub
+        # that too in a future libc.)  So we'll check first for the
+        # standard Solaris way of linking pthreads (-mt -lpthread).
+
+        ax_pthread_flags="-mt,pthread pthread $ax_pthread_flags"
+        ;;
+esac
+
+# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
+
+AS_IF([test "x$GCC" = "xyes"],
+      [ax_pthread_flags="-pthread -pthreads $ax_pthread_flags"])
+
+# The presence of a feature test macro requesting re-entrant function
+# definitions is, on some systems, a strong hint that pthreads support is
+# correctly enabled
+
+case $host_os in
+        darwin* | hpux* | linux* | osf* | solaris*)
+        ax_pthread_check_macro="_REENTRANT"
+        ;;
+
+        aix*)
+        ax_pthread_check_macro="_THREAD_SAFE"
+        ;;
+
+        *)
+        ax_pthread_check_macro="--"
+        ;;
+esac
+AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+      [ax_pthread_check_cond=0],
+      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
+
+# Are we compiling with Clang?
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [ax_cv_PTHREAD_CLANG],
+    [ax_cv_PTHREAD_CLANG=no
+     # Note that Autoconf sets GCC=yes for Clang as well as GCC
+     if test "x$GCC" = "xyes"; then
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
+     fi
+    ])
+ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
+
+ax_pthread_clang_warning=no
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        PTHREAD_CFLAGS="-pthread"
+        PTHREAD_LIBS=
+
+        ax_pthread_ok=yes
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+if test "x$ax_pthread_ok" = "xno"; then
+for ax_pthread_try_flag in $ax_pthread_flags; do
+
+        case $ax_pthread_try_flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                -mt,pthread)
+                AC_MSG_CHECKING([whether pthreads work with -mt -lpthread])
+                PTHREAD_CFLAGS="-mt"
+                PTHREAD_LIBS="-lpthread"
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $ax_pthread_try_flag])
+                PTHREAD_CFLAGS="$ax_pthread_try_flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
+                AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$ax_pthread_try_flag])
+                PTHREAD_LIBS="-l$ax_pthread_try_flag"
+                ;;
+        esac
+
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+#                       if $ax_pthread_check_cond
+#                        error "$ax_pthread_check_macro must be defined"
+#                       endif
+                        static void routine(void *a) { a = 0; }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+            [ax_pthread_ok=yes],
+            [])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        AC_MSG_RESULT([$ax_pthread_ok])
+        AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
+# Various other checks:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_CACHE_CHECK([for joinable pthread attribute],
+            [ax_cv_PTHREAD_JOINABLE_ATTR],
+            [ax_cv_PTHREAD_JOINABLE_ATTR=unknown
+             for ax_pthread_attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+                 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                                                 [int attr = $ax_pthread_attr; return attr /* ; */])],
+                                [ax_cv_PTHREAD_JOINABLE_ATTR=$ax_pthread_attr; break],
+                                [])
+             done
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
+               test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
+               test "x$ax_pthread_joinable_attr_defined" != "xyes"],
+              [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
+                                  [$ax_cv_PTHREAD_JOINABLE_ATTR],
+                                  [Define to necessary symbol if this constant
+                                   uses a non-standard name on your system.])
+               ax_pthread_joinable_attr_defined=yes
+              ])
+
+        AC_CACHE_CHECK([whether more special flags are required for pthreads],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS=no
+             case $host_os in
+             solaris*)
+             ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
+             ;;
+             esac
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
+               test "x$ax_pthread_special_flags_added" != "xyes"],
+              [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
+               ax_pthread_special_flags_added=yes])
+
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            [ax_cv_PTHREAD_PRIO_INHERIT],
+            [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
+                                             [[int i = PTHREAD_PRIO_INHERIT;]])],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
+               test "x$ax_pthread_prio_inherit_defined" != "xyes"],
+              [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
+               ax_pthread_prio_inherit_defined=yes
+              ])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        # More AIX lossage: compile with *_r variant
+        if test "x$GCC" != "xyes"; then
+            case $host_os in
+                aix*)
+                AS_CASE(["x/$CC"],
+                    [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
+                    [#handle absolute path differently from PATH based program lookup
+                     AS_CASE(["x$CC"],
+                         [x/*],
+                         [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
+                         [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
+                ;;
+            esac
+        fi
+fi
+
+test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+
+AC_SUBST([PTHREAD_LIBS])
+AC_SUBST([PTHREAD_CFLAGS])
+AC_SUBST([PTHREAD_CC])
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
+        :
+else
+        ax_pthread_ok=no
+        $2
+fi
+AC_LANG_POP
+])dnl AX_PTHREAD

--- a/rngd.c
+++ b/rngd.c
@@ -328,6 +328,8 @@ static void do_loop(int random_step)
 			if (iter->disabled)
 				continue;	/* failed, no work */
 
+			message(LOG_DAEMON|LOG_DEBUG, "Reading entropy from %s\n", iter->rng_name);
+
 			retval = iter->xread(buf, sizeof buf, iter);
 			if (retval)
 				continue;	/* failed, no work */

--- a/rngd.c
+++ b/rngd.c
@@ -486,8 +486,10 @@ int main(int argc, char **argv)
 	do_loop(arguments->random_step);
 
 	for (i=0; i < ENT_MAX; i++)
-		if (entropy_sources[i].close && entropy_sources[i].disabled == false) 
+		if (entropy_sources[i].close && entropy_sources[i].disabled == false) {
 			entropy_sources[i].close(&entropy_sources[i]);
+			free(entropy_sources[i].fipsctx);
+	}
 
 	if (pid_fd >= 0)
 		unlink(arguments->pid_file);

--- a/rngd.h
+++ b/rngd.h
@@ -68,6 +68,7 @@ struct rng {
 
 	int (*xread) (void *buf, size_t size, struct rng *ent_src);
 	int (*init) (struct rng *ent_src);
+	void (*cache) (struct rng *ent_src);
 	void (*close) (struct rng *end_src);
 	fips_ctx_t *fipsctx;
 

--- a/rngd.h
+++ b/rngd.h
@@ -68,7 +68,6 @@ struct rng {
 
 	int (*xread) (void *buf, size_t size, struct rng *ent_src);
 	int (*init) (struct rng *ent_src);
-	void (*cache) (struct rng *ent_src);
 	void (*close) (struct rng *end_src);
 	fips_ctx_t *fipsctx;
 

--- a/rngd_entsource.h
+++ b/rngd_entsource.h
@@ -48,6 +48,7 @@ extern int init_nist_entropy_source(struct rng *);
 #ifdef HAVE_JITTER
 extern int init_jitter_entropy_source(struct rng *);
 extern void close_jitter_entropy_source(struct rng *);
+extern void cache_jitter_entropy_data(struct rng *);
 #endif
 
 

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -22,6 +22,7 @@
 #error Invalid or missing autoconf build environment
 #endif
 
+#include <pthread.h>
 #include "rng-tools-config.h"
 
 #include <jitterentropy.h>
@@ -33,52 +34,125 @@
 
 static struct rand_data *ec = NULL;
 
-#define CACHE_REFILL_THRESH 4096 
-#define CACHE_SIZE 16535 
-static char cache[CACHE_SIZE];
-static size_t cache_available = 0;
-static size_t cache_idx = 0;
+static int num_threads = 1;
+struct thread_data {
+	int core_id;
+	struct rand_data *ec;
+	char *buf_ptr;
+	size_t buf_sz;
+	size_t avail;
+	size_t idx;
+	int refill;
+	pthread_mutex_t mtx;
+	pthread_cond_t cond;
+};
+
+#define MAX_THREADS 4 
+static struct thread_data tdata[MAX_THREADS];
+static pthread_t threads[MAX_THREADS];
+
+/*
+ * These must be powers of 2
+ */
+#define CACHE_REFILL_THRESH 16384 
+#define CACHE_SIZE 16384 
 
 int xread_jitter(void *buf, size_t size, struct rng *ent_src)
 {
-	size_t request = (size >= cache_available) ? cache_available : size;
-	char *bufptr = buf;
+	static int data = 0;
+	struct thread_data *current = &tdata[data];
+	ssize_t request = size;
+	size_t idx = 0;
+	size_t need = size;
+	char *bptr = buf;
 
-	memcpy(bufptr, &cache[cache_idx], request);
-	cache_idx += request;
-	cache_available -= request;
-	size -= request;
-
-	/*
- 	 * Fetch the leftover entropy
- 	 */
-	if (size) {
-		message(LOG_DAEMON|LOG_DEBUG, "JITTER rng emptied its cache\n");
-		ssize_t ret = jent_read_entropy(ec, &bufptr[request], size);
-		if (ret < 0) {
-			message(LOG_DAEMON|LOG_DEBUG, "JITTER rng fails with code %d\n", ret);
-			return 1;
+	while (need) {
+		/* if the current thread is refilling its buffer
+ 		 * just move on to the next one
+ 		 */
+		if (pthread_mutex_trylock(&current->mtx)) {
+			message(LOG_DAEMON|LOG_DEBUG, "JITTER skips thread on cpu %d\n", current->core_id);
+			goto next;
 		}
+		if (current->refill) {
+			message(LOG_DAEMON|LOG_DEBUG, "JITTER skips thread on cpu %d\n", current->core_id);
+			goto next_unlock;
+		}
+			
+		request = (need > current->avail) ? current->avail : need;
+		memcpy(&bptr[idx], &current->buf_ptr[current->idx], request);
+		idx += request;
+		current->idx += request;
+		current->avail -= request;
+		need -= request;
+
+		/* Trigger a refill if this thread is low */
+		if (current->avail < CACHE_REFILL_THRESH) {
+			current->refill = 1;
+			pthread_cond_signal(&current->cond);
+		}
+
+next_unlock:
+		pthread_mutex_unlock(&current->mtx);
+next:
+		/* Move to the next thread */
+		data = ((data+1) % num_threads);	
+		current = &tdata[data];
+		pthread_mutex_lock(&current->mtx);
 	}
+
+	pthread_mutex_unlock(&current->mtx);
 	return 0;
+
 }
 
-void cache_jitter_entropy_data(struct rng *ent_src)
+static void *thread_entropy_task(void *data)
 {
+	cpu_set_t cpuset;
+
 	ssize_t ret;
-	size_t amount=CACHE_SIZE-cache_available;
+	size_t need;
+	struct thread_data *me = data;
 
-	if (cache_available >= CACHE_REFILL_THRESH)
-		return;
+	/* STARTUP */
+	/* fill initial entropy */
+	CPU_ZERO(&cpuset);
+	CPU_SET(me->core_id, &cpuset);
+	pthread_setaffinity_np(pthread_self(), CPU_ALLOC_SIZE(me->core_id+1), &cpuset);
 
-	ret = jent_read_entropy(ec, &cache[cache_available], amount);
+	pthread_mutex_lock(&me->mtx);
+	ret = jent_read_entropy(me->ec, me->buf_ptr, me->buf_sz);
 	if (ret < 0)
-		message(LOG_DAEMON|LOG_DEBUG, "JITTER rng cache fails with code %d\n", ret);
+		message(LOG_DAEMON|LOG_DEBUG, "JITTER THREAD FAILS TO GATHER ENTROPY\n");
 
-	cache_available = CACHE_SIZE;
-	cache_idx = 0;
+	else {
+		me->avail = me->buf_sz;
+		me->refill = 0;
+	}
 
-	return;
+	/* Now go to sleep until there is more work to do */
+	do {
+		pthread_cond_wait(&me->cond, &me->mtx);
+		message(LOG_DAEMON|LOG_DEBUG, "JITTER thread on cpu %d wakes up for refill\n", me->core_id);
+		/* When we wake up, check to ensure we still have a buffer
+ 		 * Having a NULL buf_ptr is a signal to exit
+ 		 */
+		if (!me->buf_ptr)
+			break;
+
+		/* We are awake because we need to refil the buffer */
+		need = CACHE_SIZE - me->avail;
+		ret = jent_read_entropy(me->ec, me->buf_ptr, need);	
+		if (ret == 0)
+			message(LOG_DAEMON|LOG_DEBUG, "JITTER THREAD_FAILS TO GATHER ENTROPY\n");
+		me->idx = 0;
+		me->avail = CACHE_SIZE;
+		me->refill = 0;
+
+	} while (me->buf_ptr);
+
+	pthread_mutex_unlock(&me->mtx);
+	pthread_exit(NULL);
 }
 
 /*
@@ -86,29 +160,84 @@ void cache_jitter_entropy_data(struct rng *ent_src)
  */
 int init_jitter_entropy_source(struct rng *ent_src)
 {
+	cpu_set_t *cpus;
+	size_t cpusize;
+	int i;
+	int core_id = 0;
 	int ret = jent_entropy_init();
 	if(ret) {
 		message(LOG_DAEMON|LOG_WARNING, "JITTER rng fails with code %d\n", ret);
 		return 1;
 	}
 
-	ec = jent_entropy_collector_alloc(1, 0);
-	if (!ec) {
-		message(LOG_DAEMON|LOG_WARNING, "JITTER RNG COULD NOT BE ALLOCATED\n");
-		return 1;
+	/*
+ 	 * Determine the number of threads we want to run
+ 	 * 2 threads for two or more cpus
+ 	 * 4 threads for four or more cpus
+ 	 */
+	i = sysconf(_SC_NPROCESSORS_CONF);
+	cpus = CPU_ALLOC(i);
+	cpusize = CPU_ALLOC_SIZE(i);
+	CPU_ZERO_S(cpusize, cpus);
+	sched_getaffinity(0, cpusize, cpus);
+	for (i=0; (1 << i) <= MAX_THREADS; i++) {
+		if (CPU_COUNT_S(cpusize, cpus) >= (1 << i))
+			num_threads = (1 << i);
 	}
 
-	cache_jitter_entropy_data(ent_src);	
+	message(LOG_DAEMON|LOG_DEBUG, "JITTER starts %d threads\n", num_threads);
+
+	/*
+ 	 * Allocate and init the thread data that we need
+ 	 */
+	for (i=0; i < num_threads; i++) {
+		while (!CPU_ISSET_S(core_id, cpusize, cpus))
+			core_id++;
+		tdata[i].core_id = core_id;
+		core_id++;
+		tdata[i].buf_ptr = calloc(1, CACHE_SIZE);
+		tdata[i].ec = jent_entropy_collector_alloc(1, 0);
+		tdata[i].refill = 1;
+		/* Divide the buffer into num_threads equal chunks */
+		tdata[i].buf_sz = CACHE_SIZE;
+		pthread_mutex_init(&tdata[i].mtx, NULL);
+		pthread_cond_init(&tdata[i].cond, NULL);
+		pthread_create(&threads[i], NULL, thread_entropy_task, &tdata[i]);
+	}
+
+	CPU_FREE(cpus);
+	cpus = NULL;
+
+	/* Make sure all our threads are doing their jobs */
+	for (i=0; i < num_threads; i++) {
+		pthread_mutex_lock(&tdata[i].mtx);
+		while (tdata[i].refill) {
+			pthread_mutex_unlock(&tdata[i].mtx);
+			sched_yield();
+			pthread_mutex_lock(&tdata[i].mtx);
+		}
+		pthread_mutex_unlock(&tdata[i].mtx);
+	}
+		
 	message(LOG_DAEMON|LOG_INFO, "Enabling JITTER rng support\n");
 	return 0;
 }
 
 void close_jitter_entropy_source(struct rng *ent_src)
 {
-	if (ec) {
-		jent_entropy_collector_free(ec);
-		ec = NULL;
-	}
+	int i;
+
+	for (i=0; i < num_threads; i++) {
+		/* signal closure by setting buf_ptr to null */
+		pthread_mutex_lock(&tdata[i].mtx);
+		free(tdata[i].buf_ptr);
+		tdata[i].buf_ptr = NULL;
+		pthread_cond_signal(&tdata[i].cond);
+		pthread_mutex_unlock(&tdata[i].mtx);
+		pthread_join(threads[i], NULL);
+		jent_entropy_collector_free(tdata[i].ec);
+	}	
+
 	return;
 }
 

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -61,6 +61,7 @@ int xread_jitter(void *buf, size_t size, struct rng *ent_src)
 {
 	static int data = 0;
 	struct thread_data *current = &tdata[data];
+	struct thread_data *start = current;
 	ssize_t request = size;
 	size_t idx = 0;
 	size_t need = size;
@@ -98,10 +99,13 @@ next:
 		/* Move to the next thread */
 		data = ((data+1) % num_threads);	
 		current = &tdata[data];
+		if (start == current)
+			goto out;
 		pthread_mutex_lock(&current->mtx);
 	}
 
 	pthread_mutex_unlock(&current->mtx);
+out:
 	return 0;
 
 }

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -33,14 +33,52 @@
 
 static struct rand_data *ec = NULL;
 
+#define CACHE_REFILL_THRESH 4096 
+#define CACHE_SIZE 16535 
+static char cache[CACHE_SIZE];
+static size_t cache_available = 0;
+static size_t cache_idx = 0;
+
 int xread_jitter(void *buf, size_t size, struct rng *ent_src)
 {
-	ssize_t ret = jent_read_entropy(ec, buf, size);
-	if (ret < 0) {
-		message(LOG_DAEMON|LOG_DEBUG, "JITTER rng fails with code %d\n", ret);
-		return 1;
+	size_t request = (size >= cache_available) ? cache_available : size;
+	char *bufptr = buf;
+
+	memcpy(bufptr, &cache[cache_idx], request);
+	cache_idx += request;
+	cache_available -= request;
+	size -= request;
+
+	/*
+ 	 * Fetch the leftover entropy
+ 	 */
+	if (size) {
+		message(LOG_DAEMON|LOG_DEBUG, "JITTER rng emptied its cache\n");
+		ssize_t ret = jent_read_entropy(ec, &bufptr[request], size);
+		if (ret < 0) {
+			message(LOG_DAEMON|LOG_DEBUG, "JITTER rng fails with code %d\n", ret);
+			return 1;
+		}
 	}
 	return 0;
+}
+
+void cache_jitter_entropy_data(struct rng *ent_src)
+{
+	ssize_t ret;
+	size_t amount=CACHE_SIZE-cache_available;
+
+	if (cache_available >= CACHE_REFILL_THRESH)
+		return;
+
+	ret = jent_read_entropy(ec, &cache[cache_available], amount);
+	if (ret < 0)
+		message(LOG_DAEMON|LOG_DEBUG, "JITTER rng cache fails with code %d\n", ret);
+
+	cache_available = CACHE_SIZE;
+	cache_idx = 0;
+
+	return;
 }
 
 /*
@@ -59,7 +97,8 @@ int init_jitter_entropy_source(struct rng *ent_src)
 		message(LOG_DAEMON|LOG_WARNING, "JITTER RNG COULD NOT BE ALLOCATED\n");
 		return 1;
 	}
-	
+
+	cache_jitter_entropy_data(ent_src);	
 	message(LOG_DAEMON|LOG_INFO, "Enabling JITTER rng support\n");
 	return 0;
 }

--- a/rngd_rdrand.c
+++ b/rngd_rdrand.c
@@ -350,5 +350,10 @@ int init_drng_entropy_source(struct rng *ent_src)
 	if (init_aesni(key) && init_gcrypt(key))
 		return 1;	/* We need one crypto or the other... */
 
+	if (have_rdseed)
+		message(LOG_DAEMON|LOG_INFO, "Enabling RDSEED rng support\n");
+	else
+		message(LOG_DAEMON|LOG_INFO, "Enabling RDRAND rng support\n");
+
 	return 0;
 }


### PR DESCRIPTION
Since the jitterentropy library is cpu bound, lets try to accelerate it by creating a per thread cache of random data, and creating threads to collect the entropy.  This changeset creates a maximum of 4 threads, each affined to a unique cpu, to be woken with its association cache is less than full, and put back to sleep when the thread refills the cache