### PR TITLE
shrink rngd critical paths

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -598,9 +598,13 @@ int main(int argc, char **argv)
 
 		signal(SIGHUP, SIG_IGN);
 		signal(SIGPIPE, SIG_IGN);
-		signal(SIGINT, term_signal);
-		signal(SIGTERM, term_signal);
 	}
+	/*
+	 * We always catch these to ensure that we gracefully shutdown
+	 */
+	signal(SIGINT, term_signal);
+	signal(SIGTERM, term_signal);
+
 	if (arguments->ignorefail)
 		ignorefail = true;
 

--- a/rngd.c
+++ b/rngd.c
@@ -177,6 +177,9 @@ static struct rng_option jitter_options[] = {
 		.key = "refill_thresh",
 		.int_val = 16535,
 	},
+	{
+		.key = NULL,
+	}
 };
 
 static struct rng entropy_sources[ENT_MAX] = {

--- a/rngd.h
+++ b/rngd.h
@@ -121,6 +121,7 @@ extern bool quiet;
 		if ((LOG_PRI(priority) != LOG_DEBUG) || (arguments->debug == true)) {\
 			fprintf(stderr, fmt, ##args); \
 			fprintf(stderr, "\n"); \
+			fflush(stdout); \
 		} \
 	} \
 } while (0)


### PR DESCRIPTION
large mutex protected critical paths with functions in them that had high latency and high cpu usage were causing extreme latency during shutdown of the daemon.  Fix it by removing the high latency calls from the critical path.