### PR TITLE
Add support for detecting installed libjitterentropy.so

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,10 @@ if JITTER
  AM_CPPFLAGS = -I./jitterentropy-library
 endif
 
+if JITTER_DSO
+ JSUBLIB= -ljitterentropy
+endif
+
 SUBDIRS		= contrib tests $(JSUBDIR) 
 
 sbin_PROGRAMS	 = rngd
@@ -32,6 +36,11 @@ endif
 if JITTER
 rngd_SOURCES	+= rngd_jitter.c
 endif
+
+if JITTER_DSO
+rngd_SOURCES	+= rngd_jitter.c
+endif
+
 
 rngd_LDADD	= librngd.a -lsysfs $(JSUBLIB) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -57,8 +57,18 @@ AS_IF([test $target_cpu = x86_64 -o $target_cpu = i686], [AC_DEFINE([HAVE_RDRAND
 AM_CONDITIONAL([DARN], [test $target_cpu = powerpc64le])
 AS_IF([test $target_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
-AM_CONDITIONAL([JITTER], [test -f jitterentropy-library/Makefile])
-AS_IF([test -f jitterentropy-library/Makefile], [AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],[AC_MSG_NOTICE([Disabling JITTER entropy source])])
+AM_CONDITIONAL([JITTER], [false])
+AM_CONDITIONAL([JITTER_DSO], [false])
+AS_IF([test -f jitterentropy-library/Makefile],
+		[AM_CONDITIONAL([JITTER], [true])
+		 AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],
+		[AC_SEARCH_LIBS(jent_version,jitterentropy,
+			[AM_CONDITIONAL([JITTER_DSO], [true])
+			 AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],
+			[AC_MSG_NOTICE([Disabling JITTER entropy source])])])
+
+#AM_CONDITIONAL([JITTER], [test -f jitterentropy-library/Makefile])
+#AS_IF([test -f jitterentropy-library/Makefile], [AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],[AC_MSG_NOTICE([Disabling JITTER entropy source])])
 
 AS_IF(
 	[ test "x$with_nistbeacon" != "xno"],


### PR DESCRIPTION
Currently, rng-tools uses libjitterentropy built locally in this source
tree as a static library.  That is sub-optimal however, as jitterentropy
is an independently maintained project.  Ideally it would be nice to
instead load libjitterentropy as a DSO, which that project can build as.
This is the first of three steps toward moving in that direction:

1) Add support to check for and link against libjitterentropy.so, if
found on the host

2) Deprecate local building of jitterentropy as a static library

3) Remove support for building jitterentropy as a static library

This commit implements step 1.  If the configure script finds a local
copy of the jitterentropy source, it will build a static library from
it.  If not, then it will look for a local libjitterentropy.so.  If
found, it will link against that.  Otherwise, it will disable the
jitterentropy source

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>