### PR TITLE
Add cross-compile fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@ if JITTER
  JSUBDIR = jitterentropy-library
  JSUBLIB = ./jitterentropy-library/libjitterentropy.a
  AM_CPPFLAGS = -I./jitterentropy-library
+ export CC AR CFLAGS LDFLAGS
 endif
 
 if JITTER_DSO

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,8 @@ AC_PROG_CC
 AC_PROG_RANLIB
 AC_PROG_GCC_TRADITIONAL
 
+AC_CHECK_TOOLS([AR], [ar gar], :)
+
 AX_PTHREAD
 
 AM_CONDITIONAL([RDRAND], [test $target_cpu = x86_64 -o $target_cpu = i686])


### PR DESCRIPTION
Check for 'ar' as it is used for standard builds as well as jitterentropy
Export select variables when building the jitterentropy library