### PR TITLE
Test Mode: various enhancements and tweaks

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -48,6 +48,7 @@
 #include <signal.h>
 #include <limits.h>
 #include <ctype.h>
+#include <time.h>
 
 #include "rngd.h"
 #include "fips.h"
@@ -138,7 +139,8 @@ struct arguments *arguments = &default_arguments;
 
 static unsigned long ent_gathered = 0;
 static unsigned long test_iterations = 0;
-static double avg_entropy = 0;
+static double sum_entropy;
+static struct timespec start_test, end_test;
 
 static enum {
 	ENT_HWRNG = 0,
@@ -498,7 +500,7 @@ static int random_test_sink(struct rng *rng, int random_step,
 {
 	if (!ent_gathered)
 		alarm(1);
-	ent_gathered += FIPS_RNG_BUFFER_SIZE;
+	ent_gathered += (FIPS_RNG_BUFFER_SIZE * 8);
 	return 0;
 }
 
@@ -606,15 +608,16 @@ static void term_signal(int signo)
 static void alarm_signal(int signo)
 {
 
-	if (ent_gathered >= 1024)
-		message(LOG_CONS|LOG_INFO, "%d kbytes of entropy gathered per second\n",
-			ent_gathered/1024);
-	else
-		message(LOG_CONS|LOG_INFO, "%d bytes of entropy gathered per second\n",
+	if (!test_iterations) {
+		clock_gettime(CLOCK_REALTIME, &start_test);
+		sum_entropy = 0;
+	} else {
+		message(LOG_CONS|LOG_INFO, "Entropy gathered: %d bits\n",
 			ent_gathered);
-	avg_entropy = test_iterations ? ent_gathered : 
-		((avg_entropy * test_iterations) + ent_gathered) / (test_iterations + 1);
+		sum_entropy += ent_gathered;
+	}
 	ent_gathered = 0;
+	clock_gettime(CLOCK_REALTIME, &end_test);
 	test_iterations++;
 }
 
@@ -651,6 +654,7 @@ int main(int argc, char **argv)
 	int i;
 	int ent_sources = 0;
 	pid_t pid_fd = -1;
+	double test_time;
 
 	openlog("rngd", 0, LOG_DAEMON);
 
@@ -752,9 +756,18 @@ int main(int argc, char **argv)
 
 	close_all_entropy_sources();
 
-	if (arguments->test)
-		message(LOG_CONS|LOG_INFO, "Average entropy %.12e kbytes/sec over %d iterations\n",
-			avg_entropy/1024, test_iterations);
+	if (arguments->test && test_iterations > 1) {
+		test_time = (end_test.tv_sec - start_test.tv_sec);
+		test_time = ((test_time * 1.0e9) + (end_test.tv_nsec - start_test.tv_nsec)) / 1.0e9;
+
+		if ((sum_entropy/test_time) >= 1048576) {
+			message(LOG_CONS|LOG_INFO, "\nEntropy rate: %6.4g Mbits/sec averaged over %d iterations for %6.4g seconds\n",
+				(sum_entropy/test_time/1048576), (test_iterations-1), test_time);
+		} else {
+			message(LOG_CONS|LOG_INFO, "\nEntropy rate: %6.4g Kbits/sec averaged over %d iterations for %6.4g seconds\n",
+				(sum_entropy/test_time/1024), (test_iterations-1), test_time);
+		}
+	}
 
 	if (pid_fd >= 0)
 		unlink(arguments->pid_file);

--- a/rngd.h
+++ b/rngd.h
@@ -33,6 +33,10 @@
 
 #include "fips.h"
 
+#define NSECS_IN_SECOND	1.0e9
+#define MEGABITS		1048576
+#define KILOBITS		1024
+
 enum {
 	MAX_RNG_FAILURES		= 25,
 	RNG_OK_CREDIT			= 1000, /* ~1:1250 false positives */


### PR DESCRIPTION
Keep track of elapsed time, don't count on alarm(1) for timing
Use first alarm(1) as t=0
Use bits instead of bytes
Various output text tweaks

Sample results:
Entropy rate:  5.408 Kbits/sec averaged over 18 iterations for  65.01 seconds
Entropy rate:  52.34 Kbits/sec averaged over 190 iterations for    275 seconds
Entropy rate:  2.678 Mbits/sec averaged over 15 iterations for  15.06 seconds
Entropy rate:  104.2 Mbits/sec averaged over 26 iterations for     26 seconds
Entropy rate:    126 Mbits/sec averaged over 26 iterations for     26 seconds