### PR TITLE
Remove static

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "jitterentropy-library"]
-	path = jitterentropy-library
-	url = https://github.com/smuellerDD/jitterentropy-library.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,18 +1,7 @@
 ##
 ## Toplevel Makefile.am for rng-tools
 ##
-if JITTER
- JSUBDIR = jitterentropy-library
- JSUBLIB = ./jitterentropy-library/libjitterentropy.a
- AM_CPPFLAGS = -I./jitterentropy-library
- export CC AR CFLAGS LDFLAGS
-endif
-
-if JITTER_DSO
- JSUBLIB= -ljitterentropy
-endif
-
-SUBDIRS		= contrib tests $(JSUBDIR) 
+SUBDIRS		= contrib tests 
 
 sbin_PROGRAMS	 = rngd
 bin_PROGRAMS	 = rngtest
@@ -38,12 +27,8 @@ if JITTER
 rngd_SOURCES	+= rngd_jitter.c
 endif
 
-if JITTER_DSO
-rngd_SOURCES	+= rngd_jitter.c
-endif
 
-
-rngd_LDADD	= librngd.a -lsysfs $(JSUBLIB) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
+rngd_LDADD	= librngd.a -lsysfs $(LIBS) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
 
 rngd_CFLAGS	= ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
 rngd_LDFLAGS	= $(PTHREAD_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -60,17 +60,11 @@ AM_CONDITIONAL([DARN], [test $target_cpu = powerpc64le])
 AS_IF([test $target_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
 AM_CONDITIONAL([JITTER], [false])
-AM_CONDITIONAL([JITTER_DSO], [false])
-AS_IF([test -f jitterentropy-library/Makefile],
+AC_SEARCH_LIBS(jent_version,jitterentropy,
 		[AM_CONDITIONAL([JITTER], [true])
-		 AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],
-		[AC_SEARCH_LIBS(jent_version,jitterentropy,
-			[AM_CONDITIONAL([JITTER_DSO], [true])
-			 AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],
-			[AC_MSG_NOTICE([Disabling JITTER entropy source])])])
-
-#AM_CONDITIONAL([JITTER], [test -f jitterentropy-library/Makefile])
-#AS_IF([test -f jitterentropy-library/Makefile], [AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],[AC_MSG_NOTICE([Disabling JITTER entropy source])])
+		AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])
+		AC_MSG_NOTICE([Enabling JITTER entropy source])],
+		AC_MSG_NOTICE([Disabling JITTER entropy source]))
 
 AS_IF(
 	[ test "x$with_nistbeacon" != "xno"],

--- a/configure.ac
+++ b/configure.ac
@@ -60,11 +60,25 @@ AM_CONDITIONAL([DARN], [test $target_cpu = powerpc64le])
 AS_IF([test $target_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
 AM_CONDITIONAL([JITTER], [false])
-AC_SEARCH_LIBS(jent_version,jitterentropy,
-		[AM_CONDITIONAL([JITTER], [true])
-		AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])
-		AC_MSG_NOTICE([Enabling JITTER entropy source])],
-		AC_MSG_NOTICE([Disabling JITTER entropy source]))
+
+AC_ARG_ENABLE(jitterentropy,
+	AS_HELP_STRING([--disable-jitterntropy | --enable-jitterentropy=<path>],
+	[Disable jitterentropy source, or specify its location]),
+	[if [ test -d $enable_jitterentropy ]; then
+		export LDFLAGS+=-L$enable_jitterentropy;
+		export CFLAGS+=" -I$enable_jitterentropy";
+	fi],[])
+
+AS_IF(
+	[ test "x$enable_jitterentropy" != "xno" ],
+	[
+		AC_MSG_NOTICE([Searching for jitterentropy library])
+		AC_SEARCH_LIBS(jent_version,jitterentropy,
+				[AM_CONDITIONAL([JITTER], [true])
+				AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],
+				AC_MSG_NOTICE([No Jitterentropy libary found]))
+	], [AC_MSG_NOTICE([Disabling JITTER entropy source])]
+)
 
 AS_IF(
 	[ test "x$with_nistbeacon" != "xno"],


### PR DESCRIPTION
This is a pull request to remove the jitterentropy submodule from rng-tools.  The intent is to remove it and modify the configure script such that it search for the jitterentropy dso on the host system instead.