### PR TITLE
 Obey restrictions on x86_rdrand_bytes usage 

### DIFF
--- a/rngd_rdrand.c
+++ b/rngd_rdrand.c
@@ -246,7 +246,14 @@ int xread_drng(void *buf, size_t size, struct rng *ent_src)
 	if (ent_src->rng_options[DRNG_OPT_AES].int_val)
 		return xread_drng_with_aes(buf, size, ent_src);
 
-	x86_rdrand_bytes(buf, size);
+	/* NB: x86_rdrand_bytes might overrun end of buffer, if not a multiple of 8 */
+	if (size > 7)
+		x86_rdrand_bytes(buf, (size&~7));
+	if ((size&7) != 0) {
+		unsigned char tempbuf[8];
+		x86_rdrand_bytes(tempbuf, (size&7));
+		memcpy((unsigned char *)buf+(size&~7), tempbuf, (size&7));
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Make xread_drng obey the restrictions imposed by x86_rdrand_bytes.
Otherwise, problems can happen (e.g. the call to discard_initial_data results in a smashed stack, which is how I encountered this problem).