### PR TITLE
Simplify and improve performance of rngd and jitterentropy

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -430,19 +430,15 @@ int init_jitter_entropy_source(struct rng *ent_src)
 		message(LOG_DAEMON|LOG_DEBUG, "CPU Thread %d is ready\n", i);
 	}
 
+	flags = fcntl(pipefds[0], F_GETFL, 0);
+	flags |= O_NONBLOCK;
+	fcntl(pipefds[0], F_SETFL, &flags);
+
 	if (ent_src->rng_options[JITTER_OPT_USE_AES].int_val) {
 #ifdef HAVE_LIBGCRYPT
 		/*
 		 * Temporarily disable aes so we don't try to use it during init
 		 */
-
-		/*
-		 * if we use AES, then allow the pipe to return early if we 
-		 * don't fulfill the full request
-		 */
-		flags = fcntl(pipefds[1], F_GETFL, 0);
-		flags |= O_NONBLOCK;
-		fcntl(pipefds[0], F_SETFL, &flags);
 
 		message(LOG_CONS|LOG_INFO, "Initalizing AES buffer\n");
 		aes_buf = malloc(tdata[0].buf_sz);


### PR DESCRIPTION
convert jitterentropy source to use a pipe to deliver entropy.  This reduces the read size from needing to iterate over an arbitrary number of thread buffers.

Also introduce some hysteresis to allow rngd to fill the kernel entropy pool without sleeping until it is full