### PR TITLE
Pkcs11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       libxml2-dev
       libssl-dev
       libcurl3-dev
-      opensc
+      opensc-dev
       libp11-dev
 
 script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       libssl-dev
       libcurl3-dev
       opensc
+      libp11-dev
 
 script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure && make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       libxml2-dev
       libssl-dev
       libcurl3-dev
+      opensc
 
 script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure && make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ addons:
       libxml2-dev
       libssl-dev
       libcurl3-dev
-      libp11-dev
-      opensc
 
-script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure && make
+script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure --without-opensc && make
 
 after_script: 
         - make check || (cat tests/rngtesturandom.sh.log && cat tests/rngtestzero.sh.log && cat ./tests/test-suite.log)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
       libxml2-dev
       libssl-dev
       libcurl3-dev
-      opensc-dev
       libp11-dev
+      opensc
 
 script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure && make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ addons:
       libxml2-dev
       libssl-dev
       libcurl3-dev
+      libp11-dev
 
-script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure --without-opensc && make
+script: rm -rf ./jitterentropy-library/* && ./autogen.sh && ./configure && make
 
 after_script: 
         - make check || (cat tests/rngtesturandom.sh.log && cat tests/rngtestzero.sh.log && cat ./tests/test-suite.log)

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,11 +27,14 @@ if JITTER
 rngd_SOURCES	+= rngd_jitter.c
 endif
 
+rngd_LDADD	= librngd.a -lsysfs $(LIBS) ${libp11_LIBS} ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
 
-rngd_LDADD	= librngd.a -lsysfs $(LIBS) ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
+if OPENSC 
+rngd_SOURCES	+= rngd_opensc.c
+endif
 
-rngd_CFLAGS	= ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
-rngd_LDFLAGS	= $(PTHREAD_CFLAGS)
+rngd_CFLAGS	= ${opensc_CFLAGS} ${libp11_CFLAGS} ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
+rngd_LDFLAGS	= $(PTHREAD_CFLAGS) 
 
 rngtest_SOURCES	= exits.h stats.h stats.c rngtest.c
 rngtest_LDADD	= librngd.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,11 +29,11 @@ endif
 
 rngd_LDADD	= librngd.a -lsysfs $(LIBS) ${libp11_LIBS} ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
 
-if OPENSC 
-rngd_SOURCES	+= rngd_opensc.c
+if PKCS11 
+rngd_SOURCES	+= rngd_pkcs11.c
 endif
 
-rngd_CFLAGS	= ${opensc_CFLAGS} ${libp11_CFLAGS} ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
+rngd_CFLAGS	= ${pkcs11_CFLAGS} ${libp11_CFLAGS} ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
 rngd_LDFLAGS	= $(PTHREAD_CFLAGS) 
 
 rngtest_SOURCES	= exits.h stats.h stats.c rngtest.c

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,13 @@ AC_ARG_WITH([nistbeacon],
 	[with_nistbeacon=check]
 )
 
+AC_ARG_WITH([pkcs11],
+	AS_HELP_STRING([--without-pkcs11],
+		[Disable pkcs11 support. ]),
+	[],
+	[with_pkcs11=check]
+)
+
 dnl Make sure anyone changing configure.ac/Makefile.am has a clue
 AM_MAINTAINER_MODE
 AM_PROG_AS
@@ -60,6 +67,7 @@ AM_CONDITIONAL([DARN], [test $target_cpu = powerpc64le])
 AS_IF([test $target_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
 AM_CONDITIONAL([JITTER], [false])
+
 
 AC_ARG_ENABLE(jitterentropy,
 	AS_HELP_STRING([--disable-jitterentropy | --enable-jitterentropy=<path>],
@@ -90,7 +98,17 @@ AS_IF(
 	]
 )
 
+AS_IF(
+	[ test "x$with_opensc" != "xno"],
+	[
+		PKG_CHECK_MODULES([libp11], [libp11], [], [AC_MSG_ERROR([libp11 is required])])
+		PKG_CHECK_MODULES([opensc], [opensc-pkcs11], [], [AC_MSG_ERROR([opensc is required])])
+		AC_DEFINE([HAVE_OPENSC],1,[Enable OPENSC])
+	]
+)
+
 AM_CONDITIONAL([NISTBEACON], [test "x$with_nistbeacon" != "xno"])
+AM_CONDITIONAL([OPENSC], [test "x$with_opensc" != "xno"])
 
 dnl Checks for header files.
 dnl AC_HEADER_STDC

--- a/configure.ac
+++ b/configure.ac
@@ -99,16 +99,15 @@ AS_IF(
 )
 
 AS_IF(
-	[ test "x$with_opensc" != "xno"],
+	[ test "x$with_pkcs11" != "xno"],
 	[
 		PKG_CHECK_MODULES([libp11], [libp11], [], [AC_MSG_ERROR([libp11 is required])])
-		PKG_CHECK_MODULES([opensc], [opensc-pkcs11], [], [AC_MSG_ERROR([opensc is required])])
-		AC_DEFINE([HAVE_OPENSC],1,[Enable OPENSC])
+		AC_DEFINE([HAVE_PKCS11],1,[Enable PKCS11])
 	]
 )
 
 AM_CONDITIONAL([NISTBEACON], [test "x$with_nistbeacon" != "xno"])
-AM_CONDITIONAL([OPENSC], [test "x$with_opensc" != "xno"])
+AM_CONDITIONAL([PKCS11], [test "x$with_pkcs11" != "xno"])
 
 dnl Checks for header files.
 dnl AC_HEADER_STDC

--- a/rngd.8.in
+++ b/rngd.8.in
@@ -177,6 +177,15 @@ Options
 
 \fBretry_delay - \fR between each retry for retry_count above, sleep for this many seconds. May also be the special value -1, representing adaptive sleep, where each retry delay will be half the recorded execution time of the last entropy gathering round (default -1)
 
+.TP
+.B
+OPENSC (opensc) [Index 6]
+Entropy gathered via the opensc openssl engine, which can extract entropy from
+various smart card readers
+.TP
+Options
+None
+
 .SH AUTHORS
 Philipp Rumpf
 .br

--- a/rngd.8.in
+++ b/rngd.8.in
@@ -179,7 +179,7 @@ Options
 
 .TP
 .B
-OPENSC (opensc) [Index 6]
+PKCS11 (pkcs11) [Index 6]
 Entropy gathered via the opensc openssl engine, which can extract entropy from
 various smart card readers
 .TP

--- a/rngd.8.in
+++ b/rngd.8.in
@@ -184,7 +184,11 @@ Entropy gathered via the opensc openssl engine, which can extract entropy from
 various smart card readers
 .TP
 Options
-None
+\fBengine_path - \fR Set the patch for the pkcs11 engine DSO to load
+
+\fBchunk_size - \fR Some pkcs11 engines have restrictions on how much data can
+be requested at a time, this option allows for the request to be subdivided into
+smaller chunks to be satisfied
 
 .SH AUTHORS
 Philipp Rumpf

--- a/rngd.c
+++ b/rngd.c
@@ -159,6 +159,7 @@ static enum {
 static struct rng_option drng_options[] = {
 	[DRNG_OPT_AES] = {
 		.key = "use_aes",
+		.type = VAL_INT,
 		.int_val = 0,
 	},
 	{
@@ -169,6 +170,7 @@ static struct rng_option drng_options[] = {
 static struct rng_option darn_options[] = {
 	[DARN_OPT_AES] = {
 		.key = "use_aes",
+		.type = VAL_INT,
 		.int_val = 1,
 	},
 	{
@@ -179,27 +181,48 @@ static struct rng_option darn_options[] = {
 static struct rng_option jitter_options[] = {
 	[JITTER_OPT_THREADS] = {
 		.key = "thread_count",
+		.type = VAL_INT,
 		.int_val = 4,
 	},
 	[JITTER_OPT_BUF_SZ] = {
 		.key = "buffer_size",
+		.type = VAL_INT,
 		.int_val = 16535,
 	},
 	[JITTER_OPT_REFILL] = {
 		.key = "refill_thresh",
+		.type = VAL_INT,
 		.int_val = 16535,
 	},
 	[JITTER_OPT_RETRY_COUNT] = {
 		.key = "retry_count",
+		.type = VAL_INT,
 		.int_val = 1,
 	},
 	[JITTER_OPT_RETRY_DELAY] = {
 		.key = "retry_delay",
+		.type = VAL_INT,
 		.int_val = -1,
 	},
 	[JITTER_OPT_USE_AES] = {
 		.key = "use_aes",
+		.type = VAL_INT,
 		.int_val = 1,
+	},
+	{
+		.key = NULL,
+	}
+};
+
+#ifndef DEFAULT_PKCS11_ENGINE
+#define DEFAULT_PKCS11_ENGINE "/usr/lib64/opensc-pkcs11.so"
+#endif
+
+static struct rng_option pkcs11_options[] = {
+	[PKCS11_OPT_ENGINE] = {
+		.key = "engine_path",
+		.type = VAL_STRING,
+		.str_val = DEFAULT_PKCS11_ENGINE,
 	},
 	{
 		.key = NULL,
@@ -287,8 +310,8 @@ static struct rng entropy_sources[ENT_MAX] = {
 		.rng_options	= jitter_options,
 	},
 	{
-		.rng_name	= "Opensc Entropy generator",
-		.rng_sname	= "opensc",
+		.rng_name	= "PKCS11 Entropy generator",
+		.rng_sname	= "pkcs11",
 		.rng_fd		= -1,
 		.flags		= { 
 			.slow_source = 1,
@@ -300,7 +323,7 @@ static struct rng entropy_sources[ENT_MAX] = {
 #else
 		.disabled	= true,
 #endif
-		.rng_options	= NULL,
+		.rng_options	= pkcs11_options,
 	},
 };
 
@@ -348,6 +371,7 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 	char *optkey;
 	long int idx;
 	long int val;
+	char *strval;
 	bool restore = false;
 	char *search, *last_search;
 	struct rng_option *options;
@@ -380,7 +404,10 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 				entropy_sources[idx].rng_name, entropy_sources[idx].rng_sname);
 			options = entropy_sources[idx].rng_options;
 			while (options && options->key) {
-				message(LOG_CONS|LOG_INFO, "key: [%s]\tdefault value: [%d]\n", options->key, options->int_val);
+				if (options->type == VAL_INT)
+					message(LOG_CONS|LOG_INFO, "key: [%s]\tdefault value: [%d]\n", options->key, options->int_val);
+				else
+					message(LOG_CONS|LOG_INFO, "key: [%s]\tdefault value: [%s]\n", options->key, options->str_val);
 				options++;
 			}
 			return -ERANGE;
@@ -398,7 +425,7 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 		*search = ':';
 
 		last_search = search + 1;
-
+		strval = last_search;
 		val = strtoul(last_search, NULL, 10);
 		if (val == LONG_MAX) {
 			message(LOG_CONS|LOG_INFO, "rng option was not parsable\n");
@@ -408,7 +435,11 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 		options = entropy_sources[idx].rng_options;
 		while (options && options->key) {
 			if (!strcmp(optkey, options->key)) {
-				options->int_val = val;
+				if (options->type == VAL_INT)
+					options->int_val = val;
+				else
+					options->str_val = strdup(strval);
+
 				return 0;
 			}
 			options++;

--- a/rngd.c
+++ b/rngd.c
@@ -224,6 +224,11 @@ static struct rng_option pkcs11_options[] = {
 		.type = VAL_STRING,
 		.str_val = DEFAULT_PKCS11_ENGINE,
 	},
+	[PKCS11_OPT_CHUNK] = {
+		.key = "chunk_size",
+		.type = VAL_INT,
+		.int_val = 1,
+	},
 	{
 		.key = NULL,
 	}

--- a/rngd.c
+++ b/rngd.c
@@ -151,7 +151,7 @@ static enum {
 	ENT_DARN,
 	ENT_NISTBEACON,
 	ENT_JITTER,
-	ENT_OPENSC,
+	ENT_PKCS11,
 	ENT_MAX
 } entropy_indexes;
 
@@ -290,11 +290,13 @@ static struct rng entropy_sources[ENT_MAX] = {
 		.rng_name	= "Opensc Entropy generator",
 		.rng_sname	= "opensc",
 		.rng_fd		= -1,
-		.flags		= { 0 },
-#ifdef HAVE_OPENSC
-		.xread		= xread_opensc,
-		.init		= init_opensc_entropy_source,
-		.close		= close_opensc_entropy_source,
+		.flags		= { 
+			.slow_source = 1,
+		},
+#ifdef HAVE_PKCS11
+		.xread		= xread_pkcs11,
+		.init		= init_pkcs11_entropy_source,
+		.close		= close_pkcs11_entropy_source,
 #else
 		.disabled	= true,
 #endif

--- a/rngd.c
+++ b/rngd.c
@@ -151,6 +151,7 @@ static enum {
 	ENT_DARN,
 	ENT_NISTBEACON,
 	ENT_JITTER,
+	ENT_OPENSC,
 	ENT_MAX
 } entropy_indexes;
 
@@ -284,6 +285,20 @@ static struct rng entropy_sources[ENT_MAX] = {
 		.disabled	= true,
 #endif
 		.rng_options	= jitter_options,
+	},
+	{
+		.rng_name	= "Opensc Entropy generator",
+		.rng_sname	= "opensc",
+		.rng_fd		= -1,
+		.flags		= { 0 },
+#ifdef HAVE_OPENSC
+		.xread		= xread_opensc,
+		.init		= init_opensc_entropy_source,
+		.close		= close_opensc_entropy_source,
+#else
+		.disabled	= true,
+#endif
+		.rng_options	= NULL,
 	},
 };
 

--- a/rngd.h
+++ b/rngd.h
@@ -90,9 +90,25 @@ enum {
 	JITTER_OPT_MAX,
 };
 
+/*
+ * PKCS11 options
+ */
+enum {
+	PKCS11_OPT_ENGINE = 0,
+};
+
+enum option_val_type {
+	VAL_INT = 0,
+	VAL_STRING = 1,
+};
+
 struct rng_option { 
 	char *key;
-	int int_val;
+	enum option_val_type type;
+	union {
+		int int_val;
+		char *str_val;
+	};
 };
 
 /* structures to store rng information */

--- a/rngd.h
+++ b/rngd.h
@@ -95,6 +95,7 @@ enum {
  */
 enum {
 	PKCS11_OPT_ENGINE = 0,
+	PKCS11_OPT_CHUNK = 1,
 };
 
 enum option_val_type {

--- a/rngd_entsource.h
+++ b/rngd_entsource.h
@@ -50,7 +50,10 @@ extern int init_jitter_entropy_source(struct rng *);
 extern void close_jitter_entropy_source(struct rng *);
 extern void cache_jitter_entropy_data(struct rng *);
 #endif
-
+#ifdef HAVE_OPENSC
+extern int init_opensc_entropy_source(struct rng *);
+extern void close_opensc_entropy_source(struct rng *);
+#endif
 
 extern int init_tpm_entropy_source(struct rng *);
 
@@ -66,6 +69,10 @@ extern int xread_darn(void *buf, size_t size, struct rng *ent_src);
 
 #ifdef HAVE_JITTER
 extern int xread_jitter(void *buf, size_t size, struct rng *ent_src);
+#endif
+
+#ifdef HAVE_OPENSC
+extern int xread_opensc(void *buf, size_t size, struct rng *ent_src);
 #endif
 
 extern int xread_nist(void *buf, size_t size, struct rng *ent_src);

--- a/rngd_entsource.h
+++ b/rngd_entsource.h
@@ -50,9 +50,9 @@ extern int init_jitter_entropy_source(struct rng *);
 extern void close_jitter_entropy_source(struct rng *);
 extern void cache_jitter_entropy_data(struct rng *);
 #endif
-#ifdef HAVE_OPENSC
-extern int init_opensc_entropy_source(struct rng *);
-extern void close_opensc_entropy_source(struct rng *);
+#ifdef HAVE_PKCS11
+extern int init_pkcs11_entropy_source(struct rng *);
+extern void close_pkcs11_entropy_source(struct rng *);
 #endif
 
 extern int init_tpm_entropy_source(struct rng *);
@@ -71,8 +71,8 @@ extern int xread_darn(void *buf, size_t size, struct rng *ent_src);
 extern int xread_jitter(void *buf, size_t size, struct rng *ent_src);
 #endif
 
-#ifdef HAVE_OPENSC
-extern int xread_opensc(void *buf, size_t size, struct rng *ent_src);
+#ifdef HAVE_PKCS11
+extern int xread_pkcs11(void *buf, size_t size, struct rng *ent_src);
 #endif
 
 extern int xread_nist(void *buf, size_t size, struct rng *ent_src);

--- a/rngd_opensc.c
+++ b/rngd_opensc.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017, Neil Horman 
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#ifndef HAVE_CONFIG_H
+#error Invalid or missing autoconf build environment
+#endif
+
+#include <libp11.h>
+#include "rngd.h"
+#include "rngd_entsource.h"
+
+static PKCS11_CTX *ctx = NULL;
+static PKCS11_SLOT *slots, *slot;
+static unsigned int nslots;
+static char *opensc_engine_library = "/usr/lib64/opensc-pkcs11.so";
+
+int xread_opensc(void *buf, size_t size, struct rng *ent_src)
+{
+	int rc;
+	rc = PKCS11_generate_random(slot, buf, size);
+	if (rc < 0)
+		return 1;
+	return 0;
+}
+
+/*
+ * Init JITTER
+ */
+int init_opensc_entropy_source(struct rng *ent_src)
+{
+	ctx = PKCS11_CTX_new();
+	int rc;
+
+	if (!ctx) {
+		message(LOG_DAEMON|LOG_WARNING, "Unable to allocate new opensc context\n");
+		return 1;
+	}
+
+	rc = PKCS11_CTX_load(ctx, opensc_engine_library);
+	if (rc) {
+		message(LOG_DAEMON|LOG_WARNING, "Unable to load opensc engine: %s\n",
+			ERR_reason_error_string(ERR_get_error()));
+		rc = 1;
+		goto free_ctx;
+	}
+
+	rc = PKCS11_enumerate_slots(ctx, &slots, &nslots);
+	if (rc < 0) {
+		message(LOG_DAEMON|LOG_WARNING, "No opensc slots available\n");
+		rc = 1;
+		goto unload_engine;
+	}
+
+	slot = PKCS11_find_token(ctx, slots, nslots);
+	if (slot == NULL || slot->token == NULL) {
+		message(LOG_DAEMON|LOG_WARNING, "No opensc tokens available\n");
+		rc = 1;
+		goto release_slots;
+	}
+
+	message(LOG_DAEMON|LOG_INFO, "Slot manufacturer......: %s\n", slot->manufacturer);
+	message(LOG_DAEMON|LOG_INFO, "Slot description......: %s\n", slot->description);
+	message(LOG_DAEMON|LOG_INFO, "Slot token label......: %s\n", slot->token->label);
+	message(LOG_DAEMON|LOG_INFO, "Slot token manufacturer......: %s\n", slot->token->manufacturer);
+	message(LOG_DAEMON|LOG_INFO, "Slot token model......: %s\n", slot->token->model);
+	message(LOG_DAEMON|LOG_INFO, "Slot token serial......: %s\n", slot->token->serialnr);
+
+	rc = 0;
+	goto out;
+
+release_slots:
+	PKCS11_release_all_slots(ctx, slots, nslots);
+unload_engine:
+	PKCS11_CTX_unload(ctx);
+free_ctx:
+	PKCS11_CTX_free(ctx);
+out:
+	return rc;
+}
+
+void close_opensc_entropy_source(struct rng *ent_src)
+{
+	PKCS11_release_all_slots(ctx, slots, nslots);
+	PKCS11_CTX_unload(ctx);
+	PKCS11_CTX_free(ctx);
+	return;
+}
+

--- a/rngd_pkcs11.c
+++ b/rngd_pkcs11.c
@@ -29,9 +29,9 @@
 static PKCS11_CTX *ctx = NULL;
 static PKCS11_SLOT *slots, *slot;
 static unsigned int nslots;
-static char *opensc_engine_library = "/usr/lib64/opensc-pkcs11.so";
+static char *pkcs11_engine_library = "/usr/lib64/pkcs11-pkcs11.so";
 
-int xread_opensc(void *buf, size_t size, struct rng *ent_src)
+int xread_pkcs11(void *buf, size_t size, struct rng *ent_src)
 {
 	int rc;
 	rc = PKCS11_generate_random(slot, buf, size);
@@ -43,19 +43,19 @@ int xread_opensc(void *buf, size_t size, struct rng *ent_src)
 /*
  * Init JITTER
  */
-int init_opensc_entropy_source(struct rng *ent_src)
+int init_pkcs11_entropy_source(struct rng *ent_src)
 {
 	ctx = PKCS11_CTX_new();
 	int rc;
 
 	if (!ctx) {
-		message(LOG_DAEMON|LOG_WARNING, "Unable to allocate new opensc context\n");
+		message(LOG_DAEMON|LOG_WARNING, "Unable to allocate new pkcs11 context\n");
 		return 1;
 	}
 
-	rc = PKCS11_CTX_load(ctx, opensc_engine_library);
+	rc = PKCS11_CTX_load(ctx, pkcs11_engine_library);
 	if (rc) {
-		message(LOG_DAEMON|LOG_WARNING, "Unable to load opensc engine: %s\n",
+		message(LOG_DAEMON|LOG_WARNING, "Unable to load pkcs11 engine: %s\n",
 			ERR_reason_error_string(ERR_get_error()));
 		rc = 1;
 		goto free_ctx;
@@ -63,14 +63,14 @@ int init_opensc_entropy_source(struct rng *ent_src)
 
 	rc = PKCS11_enumerate_slots(ctx, &slots, &nslots);
 	if (rc < 0) {
-		message(LOG_DAEMON|LOG_WARNING, "No opensc slots available\n");
+		message(LOG_DAEMON|LOG_WARNING, "No pkcs11 slots available\n");
 		rc = 1;
 		goto unload_engine;
 	}
 
 	slot = PKCS11_find_token(ctx, slots, nslots);
 	if (slot == NULL || slot->token == NULL) {
-		message(LOG_DAEMON|LOG_WARNING, "No opensc tokens available\n");
+		message(LOG_DAEMON|LOG_WARNING, "No pkcs11 tokens available\n");
 		rc = 1;
 		goto release_slots;
 	}
@@ -95,7 +95,7 @@ out:
 	return rc;
 }
 
-void close_opensc_entropy_source(struct rng *ent_src)
+void close_pkcs11_entropy_source(struct rng *ent_src)
 {
 	PKCS11_release_all_slots(ctx, slots, nslots);
 	PKCS11_CTX_unload(ctx);

--- a/rngd_pkcs11.c
+++ b/rngd_pkcs11.c
@@ -50,8 +50,10 @@ int xread_pkcs11(void *buf, size_t size, struct rng *ent_src)
 			rc = PKCS11_generate_random(slot, ptr, chunk_len);
 			ptr += chunk_len;
 			left -= chunk_len;
-		} else
+		} else {
 			rc = PKCS11_generate_random(slot, ptr, left);
+			left = 0;
+		}
 
 		if (rc < 0)
 			return 1;
@@ -81,6 +83,8 @@ int validate_pkcs11_options(struct rng *ent_src)
 			FIPS_RNG_BUFFER_SIZE);
 		return 1;
 	}
+	
+	return 0;
 }
 
 /*

--- a/rngd_pkcs11.c
+++ b/rngd_pkcs11.c
@@ -41,6 +41,10 @@ int xread_pkcs11(void *buf, size_t size, struct rng *ent_src)
 	size_t left = size;
 	void *ptr = buf;
 
+	/* If our count is greater than our size */
+	if (!chunk_len)
+		chunk_len = left;
+
 	while (left > 0) {
 		if (left > chunk_len) {
 			rc = PKCS11_generate_random(slot, ptr, chunk_len);


### PR DESCRIPTION
add support for openssl pkcs11 engines.  This entropy source allows access to opensc compliant smart card readers as entropy generators