### PR TITLE
Make rngd_pkcs11.c explicitly link against -lcrypto

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,13 +27,13 @@ if JITTER
 rngd_SOURCES	+= rngd_jitter.c
 endif
 
-rngd_LDADD	= librngd.a -lsysfs $(LIBS) ${libp11_LIBS} ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
+rngd_LDADD	= librngd.a -lsysfs $(LIBS) ${libp11_LIBS} ${libcrypto_LIBS} ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
 
 if PKCS11 
 rngd_SOURCES	+= rngd_pkcs11.c
 endif
 
-rngd_CFLAGS	= ${pkcs11_CFLAGS} ${libp11_CFLAGS} ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
+rngd_CFLAGS	= ${pkcs11_CFLAGS} ${libp11_CFLAGS} ${libcrypto_CFLAGS} ${libxml2_CFLAGS} ${openssl_CFLAGS} $(PTHREAD_CFLAGS)
 rngd_LDFLAGS	= $(PTHREAD_CFLAGS) 
 
 rngtest_SOURCES	= exits.h stats.h stats.c rngtest.c

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,7 @@ AS_IF(
 	[ test "x$with_pkcs11" != "xno"],
 	[
 		PKG_CHECK_MODULES([libp11], [libp11], [], [AC_MSG_ERROR([libp11 is required])])
+		PKG_CHECK_MODULES([libcrypto], [libcrypto], [], [AC_MSG_ERROR([libcrypto is required])])
 		AC_DEFINE([HAVE_PKCS11],1,[Enable PKCS11])
 	]
 )


### PR DESCRIPTION
In function init_pkcs11_entropy_source(), there is a call to
ERR_reason_error_string(), which is defined in libcrypto. This causes
linking problems for rng-tools under certain configurations:

$ ./configure --disable-jitterentropy --without-nistbeacon --with-pkcs11
...
$ make
...
gcc     -pthread -g -O2 -pthread   -o rngd rngd-rngd.o rngd-rngd_entsource.o rngd-rngd_linux.o rngd-util.o  rngd-rngd_rdrand.o rdrand_asm.o   rngd-rngd_pkcs11.o librngd.a -lsysfs -lgcrypt -lsysfs  -lp11     -lgcrypt -lsysfs
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: rngd-rngd_pkcs11.o: undefined reference to symbol 'ERR_reason_error_string@@OPENSSL_1_1_0'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libcrypto.so.1.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:609: rngd] Error 1
make[2]: Leaving directory '/tmp/rng-tools'
make[1]: *** [Makefile:888: all-recursive] Error 1
make[1]: Leaving directory '/tmp/rng-tools'
make: *** [Makefile:458: all] Error 2

This symbol is defined in libcrypto:

$ readelf --dyn-syms /usr/lib64/libcrypto.so | grep ERR_reason_error_string
   314: 000000000012cf60   155 FUNC    GLOBAL DEFAULT   12 ERR_reason_error_string@@OPENSSL_1_1_0

Linking rngd against libcrypto when pkcs11 is enabled fixes the issue.

Bug: https://bugs.gentoo.org/684228