### PR TITLE
Import yocto fixes for 6.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,13 @@ AC_ARG_WITH([pkcs11],
 	[with_pkcs11=check]
 )
 
+AC_ARG_WITH([libargp],
+	AS_HELP_STRING([--without-libargp],
+		[Disable libargp support. Systems whose libc lacks argp can use libargp instead. (Default: check if libc lacks argp)]),
+	[with_libargp=$withval],
+	[with_libargp=check]
+)
+
 dnl Make sure anyone changing configure.ac/Makefile.am has a clue
 AM_MAINTAINER_MODE
 AM_PROG_AS
@@ -149,6 +156,38 @@ AS_IF(
 				AC_MSG_FAILURE([libgcrypt headers not found]); else
 				AC_MSG_NOTICE([libgcrypt support disabled])
 			fi]
+		)
+	]
+)
+
+dnl Determine if we need libargp: either user requested, or libc has no argp
+AS_IF(
+	[test "x$with_libargp" != "xyes"],
+	[
+		AC_LINK_IFELSE(
+			[AC_LANG_PROGRAM(
+				[#include <argp.h>],
+				[int argc=1; char *argv[]={"test"}; argp_parse(0,argc,argv,0,0,0); return 0;]
+				)],
+			[need_libargp=no],
+			[need_libargp=yes
+			 if test "x$with_libargp" = "xno"; then
+				AC_MSG_FAILURE([libargp disabled and libc does not have argp])
+			 fi]
+		)
+	],
+	[need_libargp=yes],
+)
+
+dnl Check for libargp
+AS_IF(
+	[test "x$need_libargp" = "xyes"],
+	[
+		AC_CHECK_LIB(
+			[argp],
+			[argp_parse],
+			[LIBS="$LIBS -largp"],
+			[AC_MSG_FAILURE([libargp not found])]
 		)
 	]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -142,7 +142,7 @@ AS_IF(
 	[test "x$with_libgcrypt" != "xno"],
 	[
 		AC_CHECK_HEADER([gcrypt.h],
-			AC_CHECK_LIB(
+			[AC_CHECK_LIB(
 				[gcrypt],
 				[gcry_check_version], ,
 				[
@@ -151,7 +151,7 @@ AS_IF(
 						AC_MSG_NOTICE([libgcrypt support disabled])
 					fi
 				]
-			),
+			)],
 			[if test "x$with_libgcrypt" != "xcheck"; then
 				AC_MSG_FAILURE([libgcrypt headers not found]); else
 				AC_MSG_NOTICE([libgcrypt support disabled])

--- a/rdrand_asm.S
+++ b/rdrand_asm.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2011-2014, Intel Corporation
  * Authors: Fenghua Yu <fenghua.yu@intel.com>,
  *          H. Peter Anvin <hpa@linux.intel.com>
+ * PIC code by: Francisco Blas Izquierdo Riera (klondike) <klondike@gentoo.org>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -172,7 +173,19 @@ ENTRY(x86_rdseed_or_rdrand_bytes)
 	jmp	4b
 ENDPROC(x86_rdseed_or_rdrand_bytes)
 
+#if defined(__PIC__)
+#define INIT_PIC() \
+	pushl	%ebx ; \
+	call    __x86.get_pc_thunk.bx ; \
+	addl    $_GLOBAL_OFFSET_TABLE_, %ebx
+#define END_PIC() \
+	popl	%ebx
+#define SETPTR(var,ptr) leal (var)@GOTOFF(%ebx),ptr
+#else
+#define INIT_PIC()
+#define END_PIC()
 #define SETPTR(var,ptr)	movl $(var),ptr
+#endif
 #define PTR0	%eax
 #define PTR1	%edx
 #define PTR2	%ecx
@@ -188,6 +201,7 @@ ENTRY(x86_aes_mangle)
 	movl	8(%ebp), %eax
 	movl	12(%ebp), %edx
 	push	%esi
+	INIT_PIC()
 #endif
 	movl	$512, CTR3	/* Number of rounds */
 	
@@ -278,6 +292,7 @@ offset = offset + 16
 	movdqa	%xmm7, (7*16)(PTR1)
 
 #ifdef __i386__
+	END_PIC()
 	pop	%esi
 	pop	%ebp
 #endif
@@ -292,6 +307,7 @@ ENTRY(x86_aes_expand_key)
 	push	%ebp
 	mov	%esp, %ebp
 	movl	8(%ebp), %eax
+	INIT_PIC()
 #endif
 
 	SETPTR(aes_round_keys, PTR1)
@@ -321,6 +337,7 @@ ENTRY(x86_aes_expand_key)
 	call	1f
 
 #ifdef __i386__
+	END_PIC()
 	pop	%ebp
 #endif
 	ret
@@ -340,6 +357,16 @@ ENTRY(x86_aes_expand_key)
 	ret
 
 ENDPROC(x86_aes_expand_key)
+
+#if defined(__i386__) && defined(__PIC__)
+	.section	.text.__x86.get_pc_thunk.bx,"axG",@progbits,__x86.get_pc_thunk.bx,comdat
+	.globl	__x86.get_pc_thunk.bx
+	.hidden	__x86.get_pc_thunk.bx
+	.type	__x86.get_pc_thunk.bx, @function
+__x86.get_pc_thunk.bx:
+	movl	(%esp), %ebx
+	ret
+#endif
 
 	.bss
 	.balign 64


### PR DESCRIPTION
This pull request is to import yocto fixes for rng-tools 6.6

see here
https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-support/rng-tools

some of those changes came from gentoo

https://packages.gentoo.org/packages/sys-apps/rng-tools
https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-apps/rng-tools
