### PR TITLE
fix build on ppc64le

### DIFF
--- a/rngd_darn.c
+++ b/rngd_darn.c
@@ -51,6 +51,13 @@ static size_t copy_avail_rand_to_buf(unsigned char *buf, size_t size, size_t cop
 
 #define AES_BLOCK 16
 #define CHUNK_SIZE AES_BLOCK * 8
+#define RDRAND_ROUNDS		512		/* 512:1 data reduction */
+
+static unsigned char key[AES_BLOCK] = {
+	0x00,0x10,0x20,0x30,0x40,0x50,0x60,0x70,
+	0x80,0x90,0xa0,0xb0,0xc0,0xd0,0xe0,0xf0
+}; /* AES data reduction key */
+
 #define THRESH_BITS 14
 
 static EVP_CIPHER_CTX *ctx = NULL;

--- a/rngd_darn.c
+++ b/rngd_darn.c
@@ -26,6 +26,7 @@
 
 
 #include <stdlib.h>
+#include <string.h>
 #include <limits.h>
 #include <sys/auxv.h>
 #include <openssl/conf.h>


### PR DESCRIPTION
darn is broken after the last changes, so fix it. Discovered by our multi-arch CI.

````
gcc -DHAVE_CONFIG_H -I.     -DDEFAULT_PKCS11_ENGINE=\"/usr/lib64/opensc-pkcs11.so\"   -I/usr/include/libxml2   -pthread -g -O2 -MT rngd-rngd_darn.o -MD -MP -MF .deps/rngd-rngd_darn.Tpo -c -o rngd-rngd_darn.o `test -f 'rngd_darn.c' || echo './'`rngd_darn.c
rngd_darn.c: In function ‘init_openssl’:
rngd_darn.c:81:2: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
   81 |  memcpy(&iv_buf[0], &darn_val, sizeof(uint64_t));
      |  ^~~~~~
rngd_darn.c:81:2: warning: incompatible implicit declaration of built-in function ‘memcpy’
rngd_darn.c:40:1: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
   39 | #include "rngd_entsource.h"
  +++ |+#include <string.h>
   40 | 
rngd_darn.c: In function ‘openssl_mangle’:
rngd_darn.c:143:47: error: ‘RDRAND_ROUNDS’ undeclared (first use in this function)
  143 |         unsigned char ciphertext[CHUNK_SIZE * RDRAND_ROUNDS];
      |                                               ^~~~~~~~~~~~~
rngd_darn.c:143:47: note: each undeclared identifier is reported only once for each function it appears in
rngd_darn.c:146:40: warning: implicit declaration of function ‘strlen’ [-Wimplicit-function-declaration]
  146 |         ciphertext_len = encrypt (tmp, strlen(tmp), key, iv_buf,
      |                                        ^~~~~~
rngd_darn.c:146:40: warning: incompatible implicit declaration of built-in function ‘strlen’
rngd_darn.c:146:40: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
rngd_darn.c:146:53: error: ‘key’ undeclared (first use in this function); did you mean ‘key_t’?
  146 |         ciphertext_len = encrypt (tmp, strlen(tmp), key, iv_buf,
      |                                                     ^~~
      |                                                     key_t
rngd_darn.c:152:9: warning: incompatible implicit declaration of built-in function ‘memcpy’
  152 |         memcpy(tmp, ciphertext, strlen(tmp));
      |         ^~~~~~
rngd_darn.c:152:9: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
rngd_darn.c: In function ‘copy_avail_rand_to_buf’:
rngd_darn.c:190:2: warning: incompatible implicit declaration of built-in function ‘memcpy’
  190 |  memcpy(&buf[copied], &darn_rand_buf[darn_buf_ptr], to_copy);
      |  ^~~~~~
rngd_darn.c:190:2: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
make[2]: *** [Makefile:758: rngd-rngd_darn.o] Error 1
````