### PR TITLE
rngd.c: only print the success message when initialize

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -795,9 +795,8 @@ int main(int argc, char **argv)
 				ent_sources++;
 				ent_src->fipsctx = malloc(sizeof(fips_ctx_t));
 				fips_init(ent_src->fipsctx, discard_initial_data(ent_src));
-                                message_entsrc(ent_src, LOG_DAEMON|LOG_INFO, "Initialized\n");
+                                message_entsrc(ent_src, LOG_DAEMON|LOG_INFO, "Initialized successfully\n");
 			} else {
-                                message_entsrc(ent_src, LOG_DAEMON|LOG_ERR, "Initialization Failed\n");
 				ent_src->disabled = true;
 			}
 		}


### PR DESCRIPTION
Only print the message for the entropy sources which
initialized successfully to avoid misleading users.

That makes sense as after check the available entropy
sources, there is logic to check whether there is at
least one available entropy source exist as below:
if (!ent_sources) {
     message(LOG_DAEMON|LOG_ERR,
             "can't open any entropy source");
     message(LOG_DAEMON|LOG_ERR,
             "Maybe RNG device modules are not loaded\n");
     return 1;
}

That's to say, only printing the message for the entropy
sources which initialized successfully is safe.

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>