### PR TITLE
fix segfault when built without rtlsdr

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -369,7 +369,7 @@ static struct rng entropy_sources[ENT_MAX] = {
 		.init	   = init_rtlsdr_entropy_source,
 		.close	  = close_rtlsdr_entropy_source,
 #else
-		.disabled       = false,
+		.disabled       = true,
 #endif
 		.rng_options    = rtlsdr_options,
 	}


### PR DESCRIPTION
When rngd is built without rtlsdr it segfaults at runtime.

```
./configure --without-nistbeacon --without-rtlsdr --without-libargp --disable-jitterentropy  --without-pkcs11

root@rpi4:/home/rng-tools# ./rngd -l
Entropy sources that are available but disabled
1: TPM RNG Device (tpm)
Available and enabled entropy sources:
0: Hardware RNG Device (hwrng)
[hwrng ]: Shutting down
[rtlsdr]: Shutting down
root@rpi4:/home/rng-tools# ./rngd -f -t -d
Initializing available sources
[hwrng ]: Initialized
Entering test mode...no entropy will be delivered to the kernel
Reading entropy from Hardware RNG Device
Reading entropy from RTLSDR software defined radio generator
Segmentation fault (core dumped)
```

```
#0  0x0000000000000000 in ?? ()
#1  0x0000000000401f54 in do_loop (random_step=64) at rngd.c:667
#2  0x00000000004017c8 in main (argc=<optimized out>, argv=<optimized out>) at rngd.c:890
```

Fix this by actually disabling the source if HAVE_RTLSDR is not defined.