### PR TITLE
configure.ac: fix --with-rtlsdr option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_ARG_WITH([pkcs11],
 
 AC_ARG_WITH([rtlsdr],
 	AS_HELP_STRING([--without-rtlsdr],
-		[Disable rtlsdr support. ])
+		[Disable rtlsdr support. ]),
 	[],
 	[with_rtlsdr=no]
 )


### PR DESCRIPTION
Add missing ',' to allow the user to explicitly disable or enable rtlsdr

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>