### PR TITLE
rngd_jitter: disambiguate call to encrypt

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -72,7 +72,7 @@ unsigned char *aes_buf;
 char key[AES_BLOCK];
 static unsigned char iv_buf[CHUNK_SIZE] __attribute__((aligned(128)));
 
-static int encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key,
+static int osslencrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key,
             unsigned char *iv, unsigned char *ciphertext)
 {
         EVP_CIPHER_CTX *ctx;
@@ -122,7 +122,7 @@ static inline int openssl_mangle(unsigned char *tmp, struct rng *ent_src)
         unsigned char ciphertext[CHUNK_SIZE * RDRAND_ROUNDS];
 
         /* Encrypt the plaintext */
-        ciphertext_len = encrypt (tmp, strlen(tmp), key, iv_buf,
+        ciphertext_len = osslencrypt (tmp, strlen(tmp), key, iv_buf,
                               ciphertext);
         if (!ciphertext_len)
                 return -1;


### PR DESCRIPTION
Commit 0f184ea7e792427fb20afe81d471b565aee96f0b disambiguate the call to encrypt in rngd_rdrand.c but did not update rngd_jitter.c.

This raise the following build failure:

```
rngd_jitter.c:75:12: error: conflicting types for 'encrypt'
 static int encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key,
            ^~~~~~~
In file included from rngd_jitter.c:27:
/home/dawncrow/buildroot-test/scripts/instance-0/output-1/host/powerpc-buildroot-linux-uclibc/sysroot/usr/include/unistd.h:1132:13: note: previous declaration of 'encrypt' was here
 extern void encrypt (char *__block, int __edflag) __THROW __nonnull ((1));
             ^~~~~~~
Makefile:770: recipe for target 'rngd-rngd_jitter.o' failed

```
Fixes:
 - http://autobuild.buildroot.org/results/0ca6bf16e3acbc94065b88c4442d6595424b77cb

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>