### PR TITLE
Nistbeacon fixes

### DIFF
--- a/rngd_nistbeacon.c
+++ b/rngd_nistbeacon.c
@@ -64,7 +64,7 @@
 #define NIST_BUF_SIZE 64 
 #define NIST_CERT "/home/nhorman/Downloads/beacon.cer"
 
-bool get_new_record = false;
+bool get_new_record = true;
 
 static int get_nist_record(struct rng *ent_src);
 

--- a/rngd_nistbeacon.c
+++ b/rngd_nistbeacon.c
@@ -689,7 +689,9 @@ static int get_nist_record(struct rng *ent_src)
 		goto out;
 	}
 
-        
+	/* Wait 60 seconds before fetching the next record */
+	alarm(60);
+
 	rc = 0;
 
 out:


### PR DESCRIPTION
Refresh the record every 60 seconds.

Note that this mechanism breaks the rngd test mode (`--test`). The breakage is originally introduced by 6f570a653a0dae833c014d336a60a0c867613982, not by this PR. This is because the test mode also uses a handler for SIGALRM, overriding nistbeacon.

Another note is the possible interference by libcurl. In certain configurations it may use the same SIGALRM mechanism to implement timeouts for connections (see https://github.com/curl/curl/blob/4a4b63daaa01ef59b131d91e8e6e6dfe275c0f08/lib/hostip.c#L723).