### PR TITLE
Travis CI: test on ppc64le and s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: trusty
 arch:
   - amd64
   - arm64
+  - ppc64le
+  - s390x
 
 compiler:
   - clang


### PR DESCRIPTION
Travis CI supports s390x and ppc64le now. It would be nice to test on those platforms.

If any issues come up with the ppc64le build in future, feel free to tag me in and I'll have a look - I have access to ppc64le systems at work. I can also help find a s390x person if that goes wrong at all.