### PR TITLE
Fix RNDADDENTROPY ioctl error for lrng

### DIFF
--- a/rngd_linux.c
+++ b/rngd_linux.c
@@ -130,7 +130,7 @@ int random_add_entropy(void *buf, size_t size)
 	memcpy(ent + 1, buf, size);
 
 	if (write_to_output == false) {
-		if (ioctl(random_fd, RNDADDENTROPY, ent) != 0) {
+		if (ioctl(random_fd, RNDADDENTROPY, ent) < 0) {
 			if (errno == ENOTTY && !arguments->daemon) {
 				/*
 				 * This isn't a real random device.


### PR DESCRIPTION
The Linux Random Number Generator (lrng) returns the number of bytes as
the result of the RNDADDENTROPY ioctl instead of 0. This causes
rng-tools to report an error like this:

  RNDADDENTROPY failed: Success

After so many failures, rng-tools will exit and stop adding entropy and
exit.

A positive ioctl return value is not indicative of an explicit error and
limiting the range of error return values to negative values will fix
this issue and allow rng-tools to support kernels using either crng or
lrng.