### PR TITLE
rngd_jitter initialization fixes

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -449,7 +449,7 @@ int init_jitter_entropy_source(struct rng *ent_src)
 
 	flags = fcntl(pipefds[0], F_GETFL, 0);
 	flags |= O_NONBLOCK;
-	fcntl(pipefds[0], F_SETFL, &flags);
+	fcntl(pipefds[0], F_SETFL, flags);
 
 	if (ent_src->rng_options[JITTER_OPT_USE_AES].int_val) {
 		/*

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -464,6 +464,17 @@ int init_jitter_entropy_source(struct rng *ent_src)
 			ent_src->rng_options[JITTER_OPT_USE_AES].int_val = 1;
 		}
 		xread_jitter(aes_buf, tdata[0].buf_sz, ent_src);
+	} else {
+		/*
+		 * Make sure that an entropy gathering thread has generated
+		 * at least some entropy before setting O_NONBLOCK and finishing
+		 * the entropy source initialization.
+		 *
+		 * This avoids "Entropy Generation is slow" log spamming that
+		 * would otherwise happen until jent_read_entropy() has run
+		 * for the first time.
+		 */
+		xread_jitter(&i, 1, ent_src);
 	}
 
 	flags = fcntl(pipefds[0], F_GETFL, 0);

--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -447,10 +447,6 @@ int init_jitter_entropy_source(struct rng *ent_src)
 		pthread_mutex_unlock(&tdata[i].statemtx);
 	}
 
-	flags = fcntl(pipefds[0], F_GETFL, 0);
-	flags |= O_NONBLOCK;
-	fcntl(pipefds[0], F_SETFL, flags);
-
 	if (ent_src->rng_options[JITTER_OPT_USE_AES].int_val) {
 		/*
 		 * Temporarily disable aes so we don't try to use it during init
@@ -469,6 +465,11 @@ int init_jitter_entropy_source(struct rng *ent_src)
 		}
 		xread_jitter(aes_buf, tdata[0].buf_sz, ent_src);
 	}
+
+	flags = fcntl(pipefds[0], F_GETFL, 0);
+	flags |= O_NONBLOCK;
+	fcntl(pipefds[0], F_SETFL, flags);
+
 	message_entsrc(ent_src,LOG_DAEMON|LOG_INFO, "Enabling JITTER rng support\n");
 	return 0;
 }


### PR DESCRIPTION
As discussed in #98,
- set O_NONBLOCK correctly and
- set O_NONBLOCK later

Closes #98