### PR TITLE
rngd: fix --debug to also filter syslog() calls

### DIFF
--- a/rngd.h
+++ b/rngd.h
@@ -166,13 +166,13 @@ extern bool quiet;
 #define message(priority,fmt,args...) do { \
 	if (quiet) \
 		break;\
+	if (arguments->debug == false && LOG_PRI(priority) == LOG_DEBUG) \
+		break;\
 	if (am_daemon) { \
 		syslog((priority), fmt, ##args); \
 	} else if (!msg_squash) { \
-		if ((LOG_PRI(priority) != LOG_DEBUG) || (arguments->debug == true)) {\
-			fprintf(stderr, fmt, ##args); \
-			fflush(stderr); \
-		} \
+		fprintf(stderr, fmt, ##args); \
+		fflush(stderr); \
 	} \
 } while (0)
 


### PR DESCRIPTION
Debug logs were only controlled by --debug flag while in --foreground
mode.  In --daemon mode /var/log/message got stuffed with details of
entropy pool refilling, which is useless in production, and hamful
when log rotation then gets rid of the more useful logs.  This is
especially true for embedded systems.

This change makes the two modes consistently only produce debug logs when
--debug is specified.

Signed-off-by: Yann Dirson <yann@blade-group.com>