### PR TITLE
Fix listing of rtlsdr options

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -274,6 +274,9 @@ static struct rng_option rtlsdr_options[] = {
 		.key = "sample_max",
 		.type = VAL_INT,
 		.int_val = 2800000,
+	},
+	{
+		.key = NULL,
 	}
 };
 


### PR DESCRIPTION
Before this commit, I noticed `use_aes` was showing up under rtlsdr
options, even though this isn't a listed option. On a different (older)
build, it was two other rogue options- `engine_path` and `chunk_size`.

    $ ./rngd -O rtlsdr
    Available options for RTLSDR software defined radio generator (rtlsdr)
    key: [device_id]	default value: [0]
    key: [freq_min]	default value: [90000000]
    key: [freq_max]	default value: [110000000]
    key: [sample_min]	default value: [1000000]
    key: [sample_max]	default value: [2800000]
    key: [use_aes]	default value: [1]

Without the `key = null` value at the end of the array, we were
combining options from multiple entropy sources. After adding the null
value, the options list is working as expected:

    $ ./rngd -O rtlsdr
    Available options for RTLSDR software defined radio generator (rtlsdr)
    key: [device_id]	default value: [0]
    key: [freq_min]	default value: [90000000]
    key: [freq_max]	default value: [110000000]
    key: [sample_min]	default value: [1000000]
    key: [sample_max]	default value: [2800000]