### PR TITLE
rngd: Fix documentation on default watermark

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -115,7 +115,7 @@ static struct argp_option options[] = {
 	  "Number of bytes written to random-device at a time (default: 64)" },
 
 	{ "fill-watermark", 'W', "n", 0,
-	  "Do not stop feeding entropy to random-device until at least n bits of entropy are available in the pool (default: 2048), 0 <= n <= 4096" },
+	  "Do not stop feeding entropy to random-device until at least n bits of entropy are available in the pool (default: 3/4 of poolsize), 0 <= n <= 4096" },
 
 	{ "quiet", 'q', 0, 0, "Suppress all messages" },
 


### PR DESCRIPTION
Default watermark level is 3/4 of available poolsize.

Signed-off-by: Tomas Melin <tomas.melin@vaisala.com>