### PR TITLE
Allow enough space in output buffer for additional block

### DIFF
--- a/rngd_rtlsdr.c
+++ b/rngd_rtlsdr.c
@@ -197,7 +197,7 @@ int xread_rtlsdr(void *buf, size_t size, struct rng *ent_src)
 	int read_len;
 	size_t gen_len;
 	char *buf_ptr = buf;
-	unsigned char outbuf[RAW_BUF_SZ];
+	unsigned char outbuf[RAW_BUF_SZ + EVP_MAX_BLOCK_LENGTH];
 	size_t copy_size;
 	size_t total_size = 0;
 	while (total_size < size) {


### PR DESCRIPTION
I use fedora which compiles rng-tools with their "hardening" build options, including a stack smashing detection.

Without this patch I get the following (using -d -f flags):
```
[rtlsdr]: Setting frequency to 96930886
Exact sample rate is: 2036915.046872 Hz
*** stack smashing detected ***: terminated
Aborted (core dumped)
```
In the great tradition of security software, after finding the culprit, I cut-n-pasted the solution from this man page.  It seems correct.

https://linux.die.net/man/3/evp_encryptfinal_ex