### PR TITLE
Fix the broken FIPS 140-2 runs test.

### DIFF
--- a/fips.c
+++ b/fips.c
@@ -93,11 +93,10 @@ static void fips_test_store(fips_ctx_t *ctx, unsigned int rng_data)
 		if (ctx->current_bit != ctx->last_bit) {
 			/* If runlength is 1-6 count it in correct bucket. 0's go in
 			   runs[0-5] 1's go in runs[6-11] hence the 6*current_bit below */
-			if (ctx->rlength < 5) {
-				ctx->runs[ctx->rlength +
-				     (6 * ctx->current_bit)]++;
-			} else {
-				ctx->runs[5 + (6 * ctx->current_bit)]++;
+			if (ctx->rlength > 4) {
+				ctx->runs[5 + (6 * ctx->last_bit)]++;
+			} else if (ctx->rlength >= 0 ) {
+				ctx->runs[ctx->rlength + (6 * ctx->last_bit)]++;
 			}
 
 			/* Check if we just failed longrun test */


### PR DESCRIPTION
There were two (related) bugs in the Runs test that this patch fixes.

The first is it was not handling the special case of ctx->rlength == -1
so if the first bit of a block was not equal to ctx->last_bit (which is
either carried over 'uselessly' from the previous block or set to 0 for
the very first bit of a testing session, but either way is 'random' at
the start of a new block), then it will try to record that event into
ctx->runs[-1 + (6 * ctx->current_bit)].  Which in the 'best' case, will
record it as a run of 0's when it should have been a run of one 1's,
and in the worst case will instead increment ctx->poker[15] (when the
fips_ctx_t struct isn't padded between those two fields).

In any reasonable length run it will hit both cases and break both the
Runs test and the Poker test results.

The second bug is that the same code was wrongly incrementing the count
for ctx->current_bit, when the run it observed is actually instead for
ctx->last_bit.  This wouldn't make a whole lot of difference to the end
result, except for the code outside of that loop which records the
final run of the block (correctly) for ctx->current_bit.  That means
the final run will record 0's or 1's into the opposite set of bins that
the main processing loop does, again (in the worst case) resulting in a
wrong count for some run length of both 0's and 1's, which some portion
of the time will cause a false (positive or negative) Runs test result.

Signed-off-by: Ron <ron@debian.org>