### PR TITLE
Fix use of GNU old-style field designator extension warning.

### DIFF
--- a/rngd_linux.c
+++ b/rngd_linux.c
@@ -160,8 +160,8 @@ int random_add_entropy(void *buf, size_t size)
 void random_sleep(void)
 {
 	struct pollfd pfd = {
-		fd:	random_fd,
-		events:	POLLOUT,
+		.fd = random_fd,
+		.events = POLLOUT,
 	};
 
 	poll(&pfd, 1, -1);


### PR DESCRIPTION
When compiling with clang(-9) there are a couple of warnings. This fixes one of them.