### PR TITLE
Fixes warning while compiling rngd_jitter.c

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -143,7 +143,7 @@ int xread_jitter(void *buf, size_t size, struct rng *ent_src)
 	size_t total;
 try_again:
 	while (need) {
-		message_entsrc(ent_src,LOG_DAEMON|LOG_DEBUG, "xread_jitter requests %d bytes from pipe\n", need);
+		message_entsrc(ent_src,LOG_DAEMON|LOG_DEBUG, "xread_jitter requests %ld bytes from pipe\n", need);
 		request = read(pipefds[0], &bptr[size-need], need);
 		if ((request < need) && ent_src->rng_options[JITTER_OPT_USE_AES].int_val) {
 			message_entsrc(ent_src,LOG_DAEMON|LOG_DEBUG, "xread_jitter falls back to AES\n");


### PR DESCRIPTION
rngd_jitter.c: In function 'xread_jitter':
rngd_jitter.c:146:48: warning: format '%d' expects argument of type 'int',
    but argument 4 has type 'ssize_t' {aka 'long int'} [-Wformat=]

It appears this issue was introduced as part of PR #94.