### PR TITLE
Stop using libsysfs and drop it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ compiler:
 addons:
   apt:
     packages:
-      libsysfs-dev
       libxml2
       libxml2-dev
       libssl-dev

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ if RTLSDR
 rngd_SOURCES	+= rngd_rtlsdr.c
 endif
 
-rngd_LDADD	= librngd.a -lsysfs $(LIBS) $(librtlsdr_LIBS) ${libp11_LIBS} ${libcrypto_LIBS} ${jansson_LIBS} ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
+rngd_LDADD	= librngd.a $(LIBS) $(librtlsdr_LIBS) ${libp11_LIBS} ${libcrypto_LIBS} ${jansson_LIBS} ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} $(PTHREAD_LIBS)
 
 if PKCS11 
 rngd_SOURCES	+= rngd_pkcs11.c

--- a/configure.ac
+++ b/configure.ac
@@ -144,11 +144,6 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 dnl AC_TYPE_SIZE_T
 dnl AC_TYPE_PID_T
 
-dnl -----------------------------
-dnl Checks for required libraries
-dnl -----------------------------
-AC_SEARCH_LIBS(sysfs_get_mnt_path, sysfs, [], [AC_MSG_ERROR([libsysfs is required])],[])
-
 dnl -------------------------------------
 dnl Checks for optional library functions
 dnl -------------------------------------

--- a/rngd_nistbeacon.c
+++ b/rngd_nistbeacon.c
@@ -39,7 +39,6 @@
 #include <time.h>
 #include <sys/mman.h>
 #include <endian.h>
-#include <sysfs/libsysfs.h>
 #include <curl/curl.h>
 #include <libxml/xmlreader.h>
 #include <jansson.h>


### PR DESCRIPTION
We are linking the whole libsysfs for just one read. Replace it with
a standard read() and remove libsysfs from requirements. This requires
an update of distribution's packaging and testing, such as rng-tools.spec
file for the rpmbuild.