### PR TITLE
Improve rngd console output readability

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -860,7 +860,7 @@ int main(int argc, char **argv)
 				entropy_sources[i].failed_init = false;
 			}
 		if (!found)
-			message(LOG_CONS|LOG_INFO, "None");
+			message(LOG_CONS|LOG_INFO, "None\n");
 		msg_squash = true;
 	} else
 		message(LOG_DAEMON|LOG_INFO, "Initializing available sources\n");


### PR DESCRIPTION
Prevent messing "None" status message with next section header:
"[...]
Entropy sources that are available but disabled
NoneAvailable and enabled entropy sources:
4: NIST Network Entropy Beacon (nist)
[...]"

Signed-off-by: Nikolai Kostrigin <nickel@altlinux.org>