### PR TITLE
rngd_jitter.c: don't set the CPU affinity mask

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -252,11 +252,6 @@ static void *thread_entropy_task(void *data)
 		me->slptm.tv_nsec = 0;
 	}
 
-	/* fill initial entropy */
-	CPU_ZERO(&cpuset);
-	CPU_SET(me->core_id, &cpuset);
-	pthread_setaffinity_np(pthread_self(), CPU_ALLOC_SIZE(me->core_id+1), &cpuset);
-
 	tmpbuf = malloc(me->buf_sz);
 	if (!tmpbuf) {
 		message_entsrc(me->ent_src,LOG_DAEMON|LOG_DEBUG, "Unable to allocate temp buffer on cpu %d\n", me->core_id);


### PR DESCRIPTION
For the jitter entropy source, each task thread will create an internal
counter timer thread when the system clock resolution is under 5MHz.

But it will introduce high cpu usage for a long time and also make random
data generate too slow if sets the CPU affinity mask of the internal counter
timer thread.

So remove the CPU affinity mask setting to avoid lots of context switch
and too high cpu load for a long time.

Signed-off-by: Zhantao Tang <zhantao.tang@windriver.com>
Signed-off-by: Mingli Yu <mingli.yu@windriver.com>