### PR TITLE
Create helpers for openssl AES use

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ man_MANS	 = rngd.8 rngtest.1
 noinst_LIBRARIES = librngd.a
 
 rngd_SOURCES	= rngd.h rngd.c	rngd_entsource.h rngd_entsource.c	\
-		  rngd_linux.h rngd_linux.c util.c
+		  rngd_linux.h rngd_linux.c util.c ossl_helpers.c
 
 if NISTBEACON
 rngd_SOURCES	+= rngd_nistbeacon.c

--- a/ossl_helpers.c
+++ b/ossl_helpers.c
@@ -1,0 +1,122 @@
+/*
+ * ossl_helpers.c -- Helper wrappers around openssl functions
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "ossl_helpers.h"
+
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+struct ossl_aes_ctx
+{
+	EVP_CIPHER_CTX *c;
+	const unsigned char *key;
+	const unsigned char *iv;
+};
+
+void ossl_aes_random_key(unsigned char *key, const unsigned char *pepper)
+{
+	static unsigned char default_key[AES_BLOCK] = {
+		0x00,0x10,0x20,0x30,0x40,0x50,0x60,0x70,
+		0x80,0x90,0xa0,0xb0,0xc0,0xd0,0xe0,0xf0
+	}; /* AES data reduction key */
+	unsigned char stack_junk[AES_BLOCK];
+	int fd, i;
+
+	/* Try getting some randomness from the kernel */
+	fd = open("/dev/urandom", O_RDONLY);
+	if (fd >= 0) {
+		int r = read(fd, key, sizeof key);
+		close(fd);
+	}
+
+	/* Mix in our default key */
+	for (i = 0; i < AES_BLOCK && pepper; i++)
+		key[i] ^= default_key[i];
+
+	/* Mix in stack junk */
+	for (i = 0; i < AES_BLOCK && pepper; i++)
+		key[i] ^= stack_junk[i];
+
+	/* Spice it up if we can */
+	for (i = 0; i < AES_BLOCK && pepper; i++)
+		key[i] ^= pepper[i];
+}
+
+
+struct ossl_aes_ctx *ossl_aes_init(const unsigned char *key,
+				   const unsigned char *iv)
+{
+	struct ossl_aes_ctx *ctx;
+
+	ctx = malloc(sizeof(*ctx));
+	if (!ctx)
+		return NULL;
+	
+	ctx->c = EVP_CIPHER_CTX_new();
+	if (!ctx->c) {
+		free(ctx);
+		return NULL;
+	}
+	ctx->key = key;
+	ctx->iv = iv;
+	return ctx;
+}
+
+void ossl_aes_exit(struct ossl_aes_ctx *ctx)
+{
+	EVP_CIPHER_CTX_free(ctx->c);
+	free(ctx);
+}
+
+int ossl_aes_encrypt(struct ossl_aes_ctx *ctx,
+		     unsigned char *plaintext, int plaintext_len,
+		     unsigned char *ciphertext)
+{
+        int len, ciphertext_len;
+
+ 	if(1 != EVP_EncryptInit_ex(ctx->c, EVP_aes_128_cbc(), NULL, ctx->key, ctx->iv))
+		return 0;
+
+	/*
+        * Provide the message to be encrypted, and obtain the encrypted output.
+        * EVP_EncryptUpdate can be called multiple times if necessary
+        */
+        if(1 != EVP_EncryptUpdate(ctx->c, ciphertext, &len, plaintext, plaintext_len))
+                return 0;
+
+        ciphertext_len = len;
+
+        /*
+        * Finalise the encryption. Further ciphertext bytes may be written at
+        * this stage.
+        */
+        if(1 != EVP_EncryptFinal_ex(ctx->c, ciphertext + len, &len))
+                return 0;
+        ciphertext_len += len;
+
+	return ciphertext_len;
+}
+

--- a/ossl_helpers.h
+++ b/ossl_helpers.h
@@ -1,0 +1,58 @@
+/*
+ * ossl_helpers.h -- Helper wrappers around openssl functions
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
+ */
+
+#ifndef OSSL_HELPERS__H
+#define OSSL_HELPERS__H
+
+#define AES_BLOCK		16
+
+struct ossl_aes_ctx;
+
+extern int ossl_aes_encrypt(struct ossl_aes_ctx *ctx,
+			    unsigned char *plaintext, int plaintext_len,
+			    unsigned char *ciphertext);
+
+extern struct ossl_aes_ctx *ossl_aes_init(const unsigned char *key,
+					  const unsigned char *iv);
+extern void ossl_aes_exit(struct ossl_aes_ctx *ctx);
+extern void ossl_aes_random_key(unsigned char *key, const unsigned char *pepper);
+
+static inline int ossl_aes_mangle(struct ossl_aes_ctx *ctx, unsigned char *data,
+				  size_t size)
+{
+        int ciphertext_len;
+
+        /*
+        * Buffer for ciphertext. Ensure the buffer is long enough for the
+        * ciphertext which may be longer than the plaintext, depending on the
+        * algorithm and mode.
+	*
+	* For AES, one extra AES block should be sufficient.
+        */
+        unsigned char ciphertext[size + AES_BLOCK];
+
+        /* Encrypt the plaintext */
+	ciphertext_len = ossl_aes_encrypt(ctx, data, size, ciphertext);
+        if (!ciphertext_len)
+                return -1;
+
+        memcpy(data, ciphertext, size);
+        return ciphertext_len;
+}
+
+#endif /* OSSL_HELPERS__H */

--- a/rngd_nistbeacon.c
+++ b/rngd_nistbeacon.c
@@ -56,6 +56,7 @@
 #include "fips.h"
 #include "exits.h"
 #include "rngd_entsource.h"
+#include "ossl_helpers.h"
 
 #define NIST_RECORD_URL "https://beacon.nist.gov/beacon/2.0/pulse/last"
 #define NIST_CERT_BASE_URL "https://beacon.nist.gov/beacon/2.0/certificate/"
@@ -133,75 +134,11 @@ X509 *cert = NULL;
 EVP_PKEY *pubkey;
 uint64_t lastpulse = 0;
 
-#define AES_BLOCK               16
 #define CHUNK_SIZE              (AES_BLOCK*8)   /* 8 parallel streams */
 #define RDRAND_ROUNDS           512             /* 512:1 data reduction */
-static unsigned char key[AES_BLOCK] = {0,};
-
-static int osslencrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key,
-            unsigned char *iv, unsigned char *ciphertext)
-{
-        EVP_CIPHER_CTX *ctx;
-
-        int len;
-
-        int ciphertext_len;
-
-        /* Create and initialise the context */
-        if(!(ctx = EVP_CIPHER_CTX_new()))
-                return 0;
-
-        if(1 != EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key, iv))
-                return 0;
-        /*
-        * Provide the message to be encrypted, and obtain the encrypted output.
-        * EVP_EncryptUpdate can be called multiple times if necessary
-        */
-        if(1 != EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len))
-                return 0;
-
-        ciphertext_len = len;
-
-        /*
-        * Finalise the encryption. Further ciphertext bytes may be written at
-        * this stage.
-        */
-        if(1 != EVP_EncryptFinal_ex(ctx, ciphertext + len, &len))
-                return 0;
-        ciphertext_len += len;
-
-        /* Clean up */
-        EVP_CIPHER_CTX_free(ctx);
-
-        return ciphertext_len;
-}
-
-static inline int openssl_mangle(unsigned char *tmp, size_t size, struct rng *ent_src)
-{
-        unsigned char xkey[AES_BLOCK];  /* Material to XOR into the key */
-        unsigned char iv_buf[CHUNK_SIZE];
-        int i;        
-        int ciphertext_len;
-
-        /*
-        * Buffer for ciphertext. Ensure the buffer is long enough for the
-        * ciphertext which may be longer than the plaintext, depending on the
-        * algorithm and mode.
-        */
-        unsigned char ciphertext[CHUNK_SIZE * RDRAND_ROUNDS];
-
-        for(i=0; i < AES_BLOCK; i++) 
-                key[i] = key[i] ^ xkey[i];
-
-        /* Encrypt the plaintext */
-        ciphertext_len = osslencrypt (tmp, size, key, iv_buf,
-                              ciphertext);
-        if (!ciphertext_len)
-                return -1;
-
-        memcpy(tmp, ciphertext, size);
-        return 0;
-}
+static unsigned char mangle_key[AES_BLOCK];
+static unsigned char mangle_iv_buf[CHUNK_SIZE];
+static struct ossl_aes_ctx *ossl_ctx;
 
 static int refill_rand(struct rng *ent_src)
 {
@@ -220,7 +157,7 @@ static int refill_rand(struct rng *ent_src)
         }
         if (block.pulseIndex == lastpulse) {
                 if (ent_src->rng_options[NIST_OPT_USE_AES].int_val) {
-                        if (openssl_mangle(nist_rand_buf, NIST_BUF_SIZE, ent_src) != 0) {
+                        if (ossl_aes_mangle(ossl_ctx, nist_rand_buf, NIST_BUF_SIZE) < 0) {
                                 message_entsrc(ent_src, LOG_DAEMON|LOG_DEBUG, "Failed mangle\n");
                                 return 1;
                         }
@@ -712,6 +649,17 @@ int init_nist_entropy_source(struct rng *ent_src)
 	int rc;
 	memset(&block, 0, sizeof (struct nist_data_block));
 
+	if (ent_src->rng_options[NIST_OPT_USE_AES].int_val) {
+		unsigned char *p;
+		int i;
+
+		ossl_aes_random_key(mangle_key, NULL);
+		for (i = 0, p = mangle_iv_buf; i < 8; i++, p += AES_BLOCK)
+			ossl_aes_random_key(p, NULL);
+			
+		ossl_ctx = ossl_aes_init(mangle_key, mangle_iv_buf);
+	}
+	
 	rc = refill_rand(ent_src);
 	if (!rc) {
 		message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING, "WARNING: NIST Randomness beacon "


### PR DESCRIPTION
Followup on comments in https://github.com/nhorman/rng-tools/pull/128

This moves the openssl code that is duplicated in several sources
to some helpers. This also fixes the use of "strlen" on raw random
data which probably didn't do what someone thought it did ...

Note: rtlsdr could probably use the random key generation helper, but
for now I have, I think, kept the code mostly equivalent