### PR TITLE
Gentoo fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 /.deps/
 /aclocal.m4
+/ar-lib
 /autom4te.cache/
 /compile
 /config.guess

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.a
 *.o
-/.deps/
+.deps/
 /aclocal.m4
 /ar-lib
 /autom4te.cache/
@@ -10,6 +10,7 @@
 /config.status
 /config.sub
 /configure
+/contrib/randstat
 /depcomp
 /install-sh
 /missing

--- a/configure.ac
+++ b/configure.ac
@@ -62,9 +62,8 @@ AM_PROG_AS
 dnl Checks for programs
 AC_PROG_CC
 AC_PROG_RANLIB
+AM_PROG_AR
 AC_PROG_GCC_TRADITIONAL
-
-AC_CHECK_TOOLS([AR], [ar gar], :)
 
 AX_PTHREAD
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,8 @@ dnl Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
 AC_INIT(rng-tools, 6.13, [Neil Horman <nhorman@tuxdriver.com>])
 AC_PREREQ(2.52)
 AC_CONFIG_SRCDIR([rngd.c])
-AC_CANONICAL_TARGET
+AC_CANONICAL_HOST
+AC_CANONICAL_TARGET dnl required for broken AX_PTHREAD
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_HEADERS([rng-tools-config.h])
 AC_CONFIG_MACRO_DIRS([m4])
@@ -67,14 +68,14 @@ AC_PROG_GCC_TRADITIONAL
 
 AX_PTHREAD
 
-AM_CONDITIONAL([RDRAND], [test $target_cpu = x86_64 -o $target_cpu = i686])
-AS_IF([test $target_cpu = x86_64 -o $target_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,[Enable RDRAND])],[])
+AM_CONDITIONAL([RDRAND], [test $host_cpu = x86_64 || $host_cpu = i686])
+AS_IF([test $host_cpu = x86_64 || $host_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,[Enable RDRAND])],[])
 
-AM_CONDITIONAL([DARN], [test $target_cpu = powerpc64le])
-AS_IF([test $target_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
+AM_CONDITIONAL([DARN], [test $host_cpu = powerpc64le])
+AS_IF([test $host_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
-AM_CONDITIONAL([RNDR], [test $target_cpu = aarch64])
-AS_IF([test $target_cpu = aarch64], [AC_DEFINE([HAVE_RNDR],1,[Enable RNDR])],[])
+AM_CONDITIONAL([RNDR], [test $host_cpu = aarch64])
+AS_IF([test $host_cpu = aarch64], [AC_DEFINE([HAVE_RNDR],1,[Enable RNDR])],[])
 AM_CONDITIONAL([JITTER], [false])
 
 AC_ARG_ENABLE(jitterentropy,

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,3 +1,2 @@
-
-EXTRA_DIST = randstat.c
-
+bin_PROGRAMS = randstat
+randstat_SOURCES = randstat.c


### PR DESCRIPTION
Hi @nhorman 
here's a bunch of fixes from Gentoo that we'd like to get merged so we don't have to carry patches downstream.

1. Use `AM_PROG_AR` over `AC_CHECK_TOOLS`
   * `AM_PROG_AR` is the canonical way to detect the archiver
      and includes workarounds for Cygwin.
2. Build `randstat` binary
3. `AC_CANONICAL_TARGET` -> `AC_CANONICAL_HOST`
   * `AC_CANONICAL_TARGET` is the type of system for which code
      will be produced, not on which it will run. This is a common
      confusion with Autoconf's target triplet.