### PR TITLE
Rewrite init_kernel_rng() to ensure proper logging

### DIFF
--- a/rngd_linux.h
+++ b/rngd_linux.h
@@ -26,9 +26,6 @@
 #include <unistd.h>
 #include <stdint.h>
 
-/* The default watermark level for this platform */
-extern int default_watermark(void);
-
 /*
  * Initialize the interface to the Linux Kernel
  * entropy pool (through /dev/random)
@@ -44,4 +41,3 @@ extern int random_add_entropy(void *buf, size_t size);
 extern void random_sleep(void);
 
 #endif /* RNGD_LINUX__H */
-


### PR DESCRIPTION
```
We want to log errors in default_watermark(), so actually we should not
call it before logging is initialized, i.e. before processing command
line switches and setting am_daemon. With that, default_watermark() is
less needed. Adjust the code by merging it into init_kernel_rng() which
is called exactly after logging is initialized and "-l" case is handled.

Also use LOG_DEBUG priority for informational messages about entropy pool.
Initialize arguments->fill_watermark with -1 so we can distinguish cases
when watermark was or was not set by a command line switch.

Signed-off-by: Vladis Dronov <vdronov@redhat.com>
```