### PR TITLE
Fix an ugly potential null deref

### DIFF
--- a/rngd_nistbeacon.c
+++ b/rngd_nistbeacon.c
@@ -285,12 +285,17 @@ static int get_json_byte_array(json_t *parent, char *key, char **val, uint32_t *
  * do that we need to return 0 from parse_nist_data_block, so the curl library
  * knows to abort the operation and fail in the call to curl_easy_perform.  That
  * in turn means checking a ton of return code when parsing out individual
- * elements.  To do that, we codify the individual element parse call, rc chedk,
+ * elements.  To do that, we codify the individual element parse call, rc check,
  * and return here in this macro.  Yes, it means returning from a function in a
  * macro, which is ugly, but thats why I'm writing this huge comment here, so
  * you won't be caught off guard.  You've been warned.
  */
-#define CURL_ABRT_IF_FAIL(call, args...) do {int ____rc = call(args); if(____rc == -1) {return 0;}} while(0)
+#define CURL_ABRT_IF_FAIL(call, args...) do {\
+int ____rc = call(args);\
+if(____rc == -1) {\
+	message_entsrc(ent_src, LOG_DAEMON|LOG_ERR, "Out of memory in %s\n", call);\
+	return 0;\
+}} while(0)
 
 /*
  * Note, I'm making the assumption that the entire xml block gets returned

--- a/rngd_nistbeacon.c
+++ b/rngd_nistbeacon.c
@@ -293,7 +293,7 @@ static int get_json_byte_array(json_t *parent, char *key, char **val, uint32_t *
 #define CURL_ABRT_IF_FAIL(call, args...) do {\
 int ____rc = call(args);\
 if(____rc == -1) {\
-	message_entsrc(ent_src, LOG_DAEMON|LOG_ERR, "Out of memory in %s\n", call);\
+	message_entsrc(ent_src, LOG_DAEMON|LOG_ERR, "Out of memory in %s\n", #call);\
 	return 0;\
 }} while(0)
 


### PR DESCRIPTION
Vladis pointed out here:
https://github.com/nhorman/rng-tools/issues/141

That we had a potential null deref in nistbeacon, that wasn't easily
fixed, and thei is the best way I can come up with to address it

Basically, when we parse a nist json block returned from a server, we
need to be aware that some memory allocations that occur in the process
might fail. If they do, we should abort the curl_easy_perform operation
so that the calling fuction knows that the block is invalid. To do that
I have to check the return code of every element parser we have (which
we use several times).  Thats alot of extra if(rc){return 0} code, so
I'm codifying it in a variadic macro that returns if the call fails

yes, I'm returning in a macro. Yes, thats ugly.  And yes, there is a
huge comment warning all who enter that code that chaos and madness lie
within.

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>