### PR TITLE
configure.ac: Add missing `test`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,8 +68,8 @@ AC_PROG_GCC_TRADITIONAL
 
 AX_PTHREAD
 
-AM_CONDITIONAL([RDRAND], [test $host_cpu = x86_64 || $host_cpu = i686])
-AS_IF([test $host_cpu = x86_64 || $host_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,[Enable RDRAND])],[])
+AM_CONDITIONAL([RDRAND], [test $host_cpu = x86_64 || test $host_cpu = i686])
+AS_IF([test $host_cpu = x86_64 || test $host_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,[Enable RDRAND])],[])
 
 AM_CONDITIONAL([DARN], [test $host_cpu = powerpc64le])
 AS_IF([test $host_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])


### PR DESCRIPTION
@nhorman I forgot to add the second `test` when removing the obsolete `-o` construct