### PR TITLE
Fix an unused variable warning

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -321,7 +321,9 @@ int validate_jitter_options(struct rng *ent_src)
 	int refill = ent_src->rng_options[JITTER_OPT_REFILL].int_val;
 	int delay = ent_src->rng_options[JITTER_OPT_RETRY_DELAY].int_val;
 	int rcount = ent_src->rng_options[JITTER_OPT_RETRY_COUNT].int_val;
+#ifndef HAVE_JITTER_NOTIME
 	int soft_timer = ent_src->rng_options[JITTER_OPT_FORCE_INT_TIMER].int_val;
+#endif
 
 	/* Need at least one thread to do this work */
 	if (!threads) {


### PR DESCRIPTION
Enclose `soft_timer` definition in `#ifndef HAVE_JITTER_NOTIME` the same
way as `soft_timer` usage is enclosed to avoid a compiler warning:
```
rng-tools-6.13/rngd_jitter.c:335:13: warning[-Wunused-variable]:
  unused variable 'soft_timer'
```
Signed-off-by: Vladis Dronov <vdronov@redhat.com>