### PR TITLE
Block termination signals for the jitter tasks

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -257,6 +257,7 @@ void jitter_thread_exit_signal(int signum)
 
 static void *thread_entropy_task(void *data)
 {
+	sigset_t blockset;
 	cpu_set_t cpuset;
 
 	ssize_t ret;
@@ -265,6 +266,12 @@ static void *thread_entropy_task(void *data)
 	struct timespec start, end;
 	int written;
 	/* STARTUP */
+
+	sigemptyset(&blockset);
+	sigaddset(&blockset, SIGINT);
+	sigaddset(&blockset, SIGTERM);
+	sigaddset(&blockset, SIGALRM);
+	pthread_sigmask(SIG_BLOCK, &blockset, NULL);
 
 	/*
 	 * Set our timeout value


### PR DESCRIPTION
To improve reliability of daemon shutdown by making sure the foreground
thread is the thread catching SIGINT and friends.

Explanation:
I'm still experiencing random freeze ups with rngd (>=5.9) on one of my embedded targets.
(Adding the full 90s systemd default timeout to a reboot.)

Disabling the jitter entropy source (-x jitter) seemed to solve the freeze ups.
Analyzing the problem I found it difficult to figure out what happens in which order
because I cannot say which of the running threads actually catches the SIGINT
and hence I decided to block SIGINT in the jitter tasks and thereby making sure
the shutdown magic starts in a more predictable manner.