### PR TITLE
Add armv6l to list of pkcs11 detected arches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ AS_IF(
 		PKG_CHECK_MODULES([libcrypto], [libcrypto], [], [AC_MSG_ERROR([libcrypto is required])])
 		AC_DEFINE([HAVE_PKCS11],1,[Enable PKCS11])
 		AS_CASE([$host_cpu],
-			[i?86|armv7hl],
+			[i?86|armv7hl|armv6l],
 			[
 				PKCS11_ENGINE=/usr/lib/opensc-pkcs11.so
 			],


### PR DESCRIPTION
This will properly set the PCKS11 library search path for armv6l devices

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>