### PR TITLE
Fix up version option handling

### DIFF
--- a/rngd.8.in
+++ b/rngd.8.in
@@ -24,7 +24,7 @@ rngd \- Check and feed random data from hardware device to kernel random device
 [\fB\-R\fR, \fB\-\-force-reseed=\fInnn\fR]
 [\fB\-q\fR, \fB\-\-quiet\fR]
 [\fB\-?\fR, \fB\-\-help\fR]
-[\fB\-V\fR, \fB\-\-version\fR]
+[\fB\-v\fR, \fB\-\-version\fR]
 .RI
 
 .SH DESCRIPTION
@@ -122,7 +122,7 @@ Suppress all messages
 \fB\-?\fR, \fB\-\-help\fR
 Give a short summary of all program options.
 .TP
-\fB\-V\fR, \fB\-\-version\fR
+\fB\-v\fR, \fB\-\-version\fR
 Print program version
 
 .SH

--- a/rngd.c
+++ b/rngd.c
@@ -591,7 +591,8 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 		break;
 	case 'v':
 		message(LOG_CONS|LOG_INFO, "%s\n", argp_program_version);
-		return -EAGAIN;
+		exit(0);
+		break;
 	case 'e': {
 		int e;
 		if ((sscanf(arg,"%i", &e) == 0) || (e < 0) || (e > 8))
@@ -847,8 +848,7 @@ int main(int argc, char **argv)
 	openlog("rngd", 0, LOG_DAEMON);
 
 	/* Parsing of commandline parameters */
-	if (argp_parse(&argp, argc, argv, 0, 0, arguments) < 0)
-		return 1;
+	argp_parse(&argp, argc, argv, ARGP_NO_HELP, 0, arguments);
 
 	if (arguments->daemon && !arguments->list) {
 		am_daemon = true;


### PR DESCRIPTION
The man page was out of date, specifying -V as the man page version
flag, when It should be -v.  Also, the arg parser wasn't handling those
options well, as it was returning an error for those valid options.  Fix
that up to just exit cleanly after printing the version info