### PR TITLE
Adjust jitterentropy detection to look for the settick function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ AS_IF(
 		AC_SEARCH_LIBS(jent_version,jitterentropy,
 				[AM_CONDITIONAL([JITTER], [true])
 				AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])
-				AC_CHECK_LIB(jitterentropy, jent_entropy_switch_notime_impl,
+				AC_CHECK_LIB(jitterentropy, jent_notime_settick,
 				[AC_DEFINE([HAVE_JITTER_NOTIME],1,[Enable JITTER_NOTIME])],
 				[],-lpthread)],
 				AC_MSG_NOTICE([No Jitterentropy library found]),-lpthread)


### PR DESCRIPTION
Theres no great way to detect if jitterentropy has the internal timer
feature enabled so we have to look for a function that is only defined
when it is enabled