### PR TITLE
Drop unused variables

### DIFF
--- a/rngd_darn.c
+++ b/rngd_darn.c
@@ -65,7 +65,6 @@ static size_t rand_bytes_served = 0;
 static int init_openssl(struct rng *ent_src)
 {
 	uint64_t darn_val;
-	int i;
 
 	ossl_aes_random_key(key, NULL);
 
@@ -140,8 +139,7 @@ static size_t copy_avail_rand_to_buf(unsigned char *buf, size_t size, size_t cop
  */
 static uint64_t get_darn()
 {
-	uint64_t darn_val;
-	darn_val = 0;
+	uint64_t darn_val = 0;
 	int i;
 
 	/*
@@ -160,7 +158,6 @@ static uint64_t get_darn()
 
 int xread_darn(void *buf, size_t size, struct rng *ent_src)
 {
-	uint64_t *darn_ptr =(uint64_t *)buf;
 	size_t copied = 0;
 
 	while (copied < size) {


### PR DESCRIPTION
And brush up code a bit. Unused variables are reported by gcc as:

```
rngd_darn.c: In function 'init_openssl':
rngd_darn.c:68:13: warning: unused variable 'i' [-Wunused-variable]
   68 |         int i;
rngd_darn.c: In function 'xread_darn':
rngd_darn.c:163:19: warning: unused variable 'darn_ptr' [-Wunused-variable]
  163 |         uint64_t *darn_ptr =(uint64_t *)buf;
```