### PR TITLE
Build Power9 code separately

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,10 +19,6 @@ if RDRAND
 rngd_SOURCES	+= rngd_rdrand.c rdrand_asm.S
 endif
 
-if DARN
-rngd_SOURCES	+= rngd_darn.c
-endif
-
 if RNDR
 rngd_SOURCES	+= rngd_rndr.c
 endif
@@ -36,6 +32,17 @@ rngd_SOURCES	+= rngd_rtlsdr.c
 endif
 
 rngd_LDADD	= librngd.a $(LIBS) $(librtlsdr_LIBS) ${libp11_LIBS} ${libcrypto_LIBS} ${jansson_LIBS} ${libcurl_LIBS} ${libxml2_LIBS} ${openssl_LIBS} ${libcap_LIBS} $(PTHREAD_LIBS)
+
+if DARN
+rngd_SOURCES	+= rngd_darn.c
+
+# Build Power9-only code with Power9
+# compile flags in a separate library
+rngd_LDADD		+= libdarn_impl.a
+noinst_LIBRARIES	+= libdarn_impl.a
+libdarn_impl_a_SOURCES	= darn_impl.c
+libdarn_impl_a_CFLAGS	= -mcpu=power9 -mtune=power9
+endif
 
 if PKCS11
 rngd_SOURCES	+= rngd_pkcs11.c

--- a/darn_impl.c
+++ b/darn_impl.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017, Neil Horman
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <limits.h>
+#include <stdint.h>
+
+/*
+ * Runs PPC64 DARN instruction, returns ULONG_MAX on error.
+ *
+ * We need this code to be a in separate library to provide
+ * special compile options for it.
+ */
+uint64_t get_darn_impl()
+{
+	uint64_t darn_val;
+	asm volatile("darn %0, 1" : "=r" (darn_val) );
+	return darn_val;
+}


### PR DESCRIPTION
The PPC64 DARN instruction is defined in ISA 3.0 which is for Power9 CPUs.
Power8 CPUs are ISA 2.07 and thus do not support DARN. Recently gcc has
limited the DARN instruction to power9 target only. Build a code with DARN
in a separate library with special compile flags.

Also add a missing check for get_darn() return value as in other places.