### PR TITLE
extend rngtestjitter timeout to a 30 second

### DIFF
--- a/tests/rngtestjitter.sh
+++ b/tests/rngtestjitter.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 kill_rngd() {
-	sleep 15
+	sleep 30
 	echo "killing"
 	killall -9 rngd
 }


### PR DESCRIPTION
Seems the current 15 second timeout is causing occasional false failures
after recent changes.