### PR TITLE
configure.ac: fix build without sys/auxv.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,14 +76,17 @@ AC_PROG_GCC_TRADITIONAL
 
 AX_PTHREAD
 
+dnl Checks for header files.
+AC_CHECK_HEADERS(sys/auxv.h)
+
 AM_CONDITIONAL([RDRAND], [test $host_cpu = x86_64 || test $host_cpu = i686])
 AS_IF([test $host_cpu = x86_64 || test $host_cpu = i686], [AC_DEFINE([HAVE_RDRAND],1,[Enable RDRAND])],[])
 
-AM_CONDITIONAL([DARN], [test $host_cpu = powerpc64le])
-AS_IF([test $host_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
+AM_CONDITIONAL([DARN], [test $host_cpu = powerpc64le -a "$ac_cv_header_sys_auxv_h" = "yes"])
+AS_IF([test $host_cpu = powerpc64le -a "$ac_cv_header_sys_auxv_h" = "yes"], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
 
-AM_CONDITIONAL([RNDR], [test $host_cpu = aarch64])
-AS_IF([test $host_cpu = aarch64], [AC_DEFINE([HAVE_RNDR],1,[Enable RNDR])],[])
+AM_CONDITIONAL([RNDR], [test $host_cpu = aarch64 -a "$ac_cv_header_sys_auxv_h" = "yes"])
+AS_IF([test $host_cpu = aarch64 -a "$ac_cv_header_sys_auxv_h" = "yes"], [AC_DEFINE([HAVE_RNDR],1,[Enable RNDR])],[])
 AM_CONDITIONAL([JITTER], [false])
 
 AC_ARG_ENABLE(jitterentropy,


### PR DESCRIPTION
Fix the following build failure on aarch64 without `sys/auxv.h` (e.g. on uclibc) raised since version 6.13 and https://github.com/nhorman/rng-tools/commit/9070a04adfcd21ec3839ee8ff190e7130ccd5c9b:

```
rngd_rndr.c:34:10: fatal error: sys/auxv.h: No such file or directory
   34 | #include <sys/auxv.h>
      |          ^~~~~~~~~~~~
```

The same issue could be raised on powerpc64le since version 6.11 and https://github.com/nhorman/rng-tools/commit/ade348cdb90c25b44b203fd4e9c33ec4bccff323

Fixes:
 - http://autobuild.buildroot.org/results/41d5ab9e67eb0d8af8d789fc94d4366f130a7fb2

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>