### PR TITLE
configure.ac: fix jitterentropy internal timers detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,9 +104,12 @@ AS_IF(
 		AC_SEARCH_LIBS(jent_version,jitterentropy,
 				[AM_CONDITIONAL([JITTER], [true])
 				AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])
-				AC_CHECK_LIB(jitterentropy, jent_notime_init,
-				[],
-				[AC_DEFINE([HAVE_JITTER_NOTIME],1, [Enable JITTER_NOTIME])],-lpthread)],
+				AC_CHECK_LIB(jitterentropy, jent_notime_settick,
+				[
+					AC_DEFINE([HAVE_JITTER_NOTIME],1,[Enable JITTER_NOTIME])
+					AC_DEFINE([JENT_CONF_ENABLE_INTERNAL_TIMER],1,[Enable JENT_CONF_ENABLE_INTERNAL_TIMER])
+				],
+				[],-lpthread)],
 				AC_MSG_NOTICE([No Jitterentropy library found]),-lpthread)
 	], [AC_MSG_NOTICE([Disabling JITTER entropy source])]
 )

--- a/rngd_qrypt.c
+++ b/rngd_qrypt.c
@@ -315,7 +315,7 @@ static void *refill_task(void *data __attribute__((unused)))
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
 
 	list = curl_slist_append(list, "Accept: application/json");
-	list = curl_slist_append(list, bearer); 
+	list = curl_slist_append(list, bearer);
 
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 	
@@ -405,7 +405,6 @@ int xread_qrypt(void *buf, size_t size, struct rng *ent_src)
 	size_t to_copy;
 	uint8_t *buf_ptr = buf;
 	size_t oldsize = size;
-	int i;
 
 	if (backoff_active)
 	{
@@ -453,7 +452,7 @@ int xread_qrypt(void *buf, size_t size, struct rng *ent_src)
 
 
 /*
- * Init QRYPT 
+ * Init QRYPT
  */
 int init_qrypt_entropy_source(struct rng *ent_src)
 {


### PR DESCRIPTION
Use visibility of jent_notime_settick() to detect if jitterentropy library is built with internal timers. The code related is:

```
[ src/jitterentropy-timer.h ]
#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
int jent_notime_settick(struct rand_data *ec);
#else /* JENT_CONF_ENABLE_INTERNAL_TIMER */
static inline int jent_notime_settick(struct rand_data *ec)
{ (void)ec; return 0; }
#endif /* JENT_CONF_ENABLE_INTERNAL_TIMER */
```

Fix couple of whitespace and unused variable issues to please code scanners.

Thanks Neil for qcrypt, this looks like a great feature!