### PR TITLE
rngd_jitter: decreased a thread on some of ARM platform

### DIFF
--- a/rngd_jitter.c
+++ b/rngd_jitter.c
@@ -454,7 +454,11 @@ int init_jitter_entropy_source(struct rng *ent_src)
 		CPU_SET(0, cpus);
 	}
 
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__ARM_ARCH_7A__)
+	num_threads = CPU_COUNT_S(cpusize, cpus) - 1;
+#else
 	num_threads = CPU_COUNT_S(cpusize, cpus);
+#endif
 
 	if (num_threads >= ent_src->rng_options[JITTER_OPT_THREADS].int_val)
 		num_threads = ent_src->rng_options[JITTER_OPT_THREADS].int_val;


### PR DESCRIPTION
Dear maintainer,

Due to ARM cpu pipeline less than x86 or other arch, it would use more effort to generate data from jitter. this might block other process during system bootup, so decreased a thread to reserve resource for other process when system bootup. Just tested on armv7 and aarch64 platform only, so add armv7 & aarch64 macro only.


Thanks!
