### PR TITLE
Fix ignorefail

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -728,10 +728,11 @@ static int update_kernel_random(struct rng *rng, int random_step,
 	unsigned char *buf, fips_ctx_t *fipsctx_in)
 {
 	unsigned char *p;
-	int fips;
+	int fips = 0;
 	int rc;
 
-	fips = fips_run_rng_test(fipsctx_in, buf);
+	if (!arguments->ignorefail)
+		fips = fips_run_rng_test(fipsctx_in, buf);
 	if (fips && !arguments->ignorefail)
 		return 1;
 


### PR DESCRIPTION
When -i used, the fips_run_rng_test() should not be called in update_kernel_random().

Signed-off-by: lvgenggeng <lvgenggeng@uniontech.com>