### PR TITLE
Fix random_step boundary

### DIFF
--- a/rngd.c
+++ b/rngd.c
@@ -623,6 +623,8 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 	case 's':
 		if (sscanf(arg, "%i", &arguments->random_step) == 0)
 			argp_usage(state);
+		if (arguments->random_step > FIPS_RNG_BUFFER_SIZE || arguments->random_step < 0)
+			arguments->random_step = FIPS_RNG_BUFFER_SIZE
 		break;
 	case 'W': {
 		int n;


### PR DESCRIPTION
As buffer size in do_loop() is FIPS_RNG_BUFFER_SIZE, so the random_step should not bigger. If random_step > FIPS_RNG_BUFFER_SIZE,  update_kernel_random() will not write any date.

Signed-off-by: lvgenggeng <lvgenggeng@uniontech.com>