### PR TITLE
Adjust error message when pkcs11 engine is not installed

### DIFF
--- a/rngd.8.in
+++ b/rngd.8.in
@@ -134,7 +134,7 @@ Print program version
 .SH
 ENTROPY SOURCES
 .P
- Rngd is made up of multiple entropy sources, the data from which is
+Rngd is made up of multiple entropy sources, the data from which is
 aggregated and fed into the kernels entropy pool.  Note that not all entropy
 sources are available on all systems, and if an entropy source is enabled for a
 system on which it is not appropriate (or possible) to use, it may fail
@@ -235,7 +235,10 @@ Options
 .B
 PKCS11 (pkcs11) 
 Entropy gathered via the opensc openssl engine, which can extract entropy from
-various smart card readers
+various smart card readers. Install a package for your distribution containing
+pkcs11 endpoint library to gather smartcard entropy. This is \fBopensc\fR for
+Fedora, \fBopensc-pkcs11\fR for Debian/Ubuntu or another package containing
+opensc-pkcs11.so.
 .TP
 Options
 \fBengine_path - \fR Set the patch for the pkcs11 engine DSO to load

--- a/rngd_pkcs11.c
+++ b/rngd_pkcs11.c
@@ -67,19 +67,25 @@ int validate_pkcs11_options(struct rng *ent_src)
 	struct stat sbuf;
 
 	if (stat(ent_src->rng_options[PKCS11_OPT_ENGINE].str_val, &sbuf) == -1) {
-		message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING, "PKCS11 Engine %s Error: %s\n",
-			ent_src->rng_options[PKCS11_OPT_ENGINE].str_val,
-			strerror(errno));
+		if (errno == ENOENT) {
+			message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING,"No PKCS11 endpoint %s found\n",
+				ent_src->rng_options[PKCS11_OPT_ENGINE].str_val);
+			message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING,"Install opensc/opensc-pkcs11/etc"
+				" if you would like to gather smartcard entropy\n");
+		} else
+			message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING, "PKCS11 Engine %s Error: %s\n",
+				ent_src->rng_options[PKCS11_OPT_ENGINE].str_val,
+				strerror(errno));
 		return 1;
 	}
 
 	if (!ent_src->rng_options[PKCS11_OPT_CHUNK].int_val) {
-		message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING, "PKCS11 Engine chunk size cannot be 0\n");
+		message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING, "PKCS11 Engine: chunk size cannot be 0\n");
 		return 1;
 	}
 	
 	if (ent_src->rng_options[PKCS11_OPT_CHUNK].int_val > FIPS_RNG_BUFFER_SIZE) {
-		message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING, "PKCS11 Engine chunk size cannot be larger than %d\n",
+		message_entsrc(ent_src,LOG_DAEMON|LOG_WARNING, "PKCS11 Engine: chunk size cannot be larger than %d\n",
 			FIPS_RNG_BUFFER_SIZE);
 		return 1;
 	}


### PR DESCRIPTION
Link: https://bugzilla.redhat.com/show_bug.cgi?id=1845854