### PR TITLE
mix data fed to the kernel byte-wise from multiple sources

### DIFF
--- a/rngd.h
+++ b/rngd.h
@@ -176,6 +176,12 @@ struct rng {
 		/* Intermittent sources - may sometimes fail to produce entropy */
 		unsigned int intermittent_source : 1;
 	} flags;
+	struct entropy_buf {
+		/* structure to store entropy from a source before mixing it with other sources */
+		unsigned char entropy[FIPS_RNG_BUFFER_SIZE];
+		bool valid;
+		int used_pos;
+	} entropy_buf;
 	int (*xread) (void *buf, size_t size, struct rng *ent_src);
 	int (*init) (struct rng *ent_src);
 	void (*close) (struct rng *end_src);


### PR DESCRIPTION
Before this patch entropy data was gathered from one source, fed to the kernel, then the next source was gathered, fed, and so on.

With the default config on a modern kernel this lead to one source being used for 195 minutes before switching to the next source. Should one source not be as random as expected, the impact of this problem can be reduced by mixing the bad entropy with data from other sources. The long usage time of 195 minutes for one source didn't facilitate this well.

This patch changes this behavior and first gathers data from each enabled source and checks it. then a byte from each valid source block is taken in turn until the block to feed to the kernel (random_step) is filled. This mixed data is then fed to the kernel.

This fixes issue #201 