### PR TITLE
add --use-slow-sources option

### DIFF
--- a/rngd.8.in
+++ b/rngd.8.in
@@ -22,6 +22,7 @@ rngd \- Check and feed random data from hardware device to kernel random device
 [\fB\-t\fR, \fB\-\-test\fR]
 [\fB\-W\fR, \fB\-\-fill-watermark=\fInnn\fR]
 [\fB\-R\fR, \fB\-\-force-reseed=\fInnn\fR]
+[\fB\-u\fR, \fB\-\-use-slow-sources\fR]
 [\fB\-D\fR, \fB\-\-drop-privileges=\fIuser:group\fR]
 [\fB\-q\fR, \fB\-\-quiet\fR]
 [\fB\-?\fR, \fB\-\-help\fR]
@@ -116,6 +117,11 @@ For newer kernels which support non-blocking entropy pools, it is still
 beneficial to periodically add fresh entropy as a reseeding event.
 --force-reseed defines the number of seconds between which fresh entropy is
 added to the kernel entropy pool.  Defaults to 5 minutes.
+.TP
+\fB\-u\fR, \fB\-\-use-slow-sources\fR
+The entropy sources nist, jitter and pkcs11 are considered to be slow in providing entropy.
+By default their data is only used after all other sources failed to provide valid entropy 
+a 100 times over. With this option rngd always tries to gather entropy from these sources too.
 .TP
 \fB\-D\fR, \fB\-\-drop-privileges=\fIuser:group\fR
 Drop privileges to a user and a group specified after initialization. A user

--- a/rngd.c
+++ b/rngd.c
@@ -130,6 +130,8 @@ static struct argp_option options[] = {
 
 	{ "force-reseed", 'R', "n", 0, "Time in seconds to force adding entropy to the random device" },
 
+	{ "use-slow-sources", 'u', 0, 0, "Always gather entropy from sources considered as \"slow\" too" },
+
 	{ "drop-privileges", 'D', "user:group", 0, "Drop privileges to a user and group specified" },
 
 	{ 0 },
@@ -146,6 +148,7 @@ static struct arguments default_arguments = {
 	.ignorefail	= false,
 	.entropy_count	= 8,
 	.force_reseed	= 60 * 5,
+	.use_slow_sources = false,
 	.drop_privs = false,
 };
 struct arguments *arguments = &default_arguments;
@@ -683,6 +686,10 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 			arguments->force_reseed = R;
 		break;
 	}
+	case 'u': {
+		arguments->use_slow_sources = true;
+		break;
+	}
 	case 'D': {
 		struct passwd *usrent;
 		struct group *grpent;
@@ -942,7 +949,7 @@ continue_trying:
 			int rc;
 			/*message(LOG_CONS|LOG_INFO, "I is %d\n", i);*/
 			iter = &entropy_sources[i];
-			if (!try_slow_sources && iter->flags.slow_source)
+			if (!try_slow_sources && !arguments->use_slow_sources && iter->flags.slow_source)
 				continue;
 
 		retry_same:

--- a/rngd.h
+++ b/rngd.h
@@ -59,6 +59,7 @@ struct arguments {
 	bool enable_tpm;
 	int entropy_count;
 	int force_reseed;
+	bool use_slow_sources;
 
 	bool drop_privs;
 	uid_t drop_uid;


### PR DESCRIPTION
The entropy sources nist, jitter and pkcs11 are considered to be slow in providing entropy. By default their data is only used after all other sources failed to provide valid entropy a 100 times over. With this option rngd always tries to gather entropy from these sources too.

Having this option is useful when you want to feed the kernel data from a mix of as many independent sources as possible. The concern of for example jitter being too slow to supply a sufficient amount of entropy data is only relevant when rngd needs to supply entropy to the kernel often and in short order. With modern kernels not signaling a low watermark anymore and thus only the known force-reseed time is used, you can ensure that jitter will be able to provide enough data at configuration time.

When comparing the default timeout of 5 seconds for the jitter source with the default force-reseed time of 5 minutes, you can see that jitter will often be able to provide enough data.

Different take on this issue after discussion in #202