### PR TITLE
configure: Fix m4 quoting issue in libargp probe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,7 +196,7 @@ AS_IF(
 		AC_LINK_IFELSE(
 			[AC_LANG_PROGRAM(
 				[#include <argp.h>],
-				[int argc=1; char *argv[]={"test"}; argp_parse(0,argc,argv,0,0,0); return 0;]
+				[[int argc=1; char *argv[]={"test"}; argp_parse(0,argc,argv,0,0,0); return 0;]]
 				)],
 			[need_libargp=no],
 			[need_libargp=yes


### PR DESCRIPTION
Without the surrounding `[]`, m4 drops the inner `[]`, treating, `argv[]` as `argv`.  This results in an incorrect argument type for `argp_parse`, causing the probe to fail with future compilers due to type error.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
