### PR TITLE
Add jitter timeout to man page & increase jitter timeout

### DIFF
--- a/rngd.8.in
+++ b/rngd.8.in
@@ -237,6 +237,8 @@ Options
 
 \fBforce_soft_timer - \fR on platforms with a hardware timer that is too coarse to sample jitter, we can instead use a software based timer loop.  Detection and use of this mechanism is automatic, but this can be useful for testing purposes
 
+\fBtimeout - \fR maximum time in seconds to wait until the source must have delivered a block of entropy. On slower hardware it may be necessary to increase this value to ensure jitter can reliably be initialized (default 10)
+
 .TP
 .B
 PKCS11 (pkcs11) 

--- a/rngd.c
+++ b/rngd.c
@@ -236,7 +236,7 @@ static struct rng_option jitter_options[] = {
 	[JITTER_OPT_TIMEOUT] = {
 		.key = "timeout",
 		.type = VAL_INT,
-		.int_val = 5,
+		.int_val = 10,
 	},
 	{
 		.key = NULL,


### PR DESCRIPTION
Other users reported timeout issues with the current default timeout of 5 seconds in issue #198.
    
While testing jitter during development I did notice that on some systems sometimes also would fail to initialize during startup.
    
 Since these issues don't seem to be that uncommon, I think the **default timeout should be increased to 10 seconds**. Since with both reported cases the 5 second timeout was marginal, 5 seconds more should improve the probabilty of a reliable
 start on these systems by a great margin.
    
If jitter is able to provide enough entropy faster, which it will on the majority
of systems and program starts, then you don't have to wait longer because of this change.
The longer timeout will only affect systems where jitter is enabled (probably due to
a default config), but fails to initialize even after 10 seconds.

Also document the timeout option of the jitter source in the man page which was previously undocumented.