### PR TITLE
Generate rngd.service to match directory rngd was installed into

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /rng-tools-config.h.in
 /rngd
 /rngd.8
+/rngd.service
 /rngtest
 /rngtest.1
 /stamp-h1

--- a/configure.ac
+++ b/configure.ac
@@ -231,5 +231,5 @@ dnl --------------------------
 dnl autoconf output generation
 dnl --------------------------
 
-AC_CONFIG_FILES([Makefile contrib/Makefile tests/Makefile rngd.8 rngtest.1])
+AC_CONFIG_FILES([Makefile contrib/Makefile tests/Makefile rngd.8 rngd.service rngtest.1])
 AC_OUTPUT

--- a/rngd.service.in
+++ b/rngd.service.in
@@ -5,7 +5,7 @@ ConditionVirtualization=!container
 # The "-f" option is required for the systemd service rngd to work with Type=simple
 [Service]
 Type=simple
-ExecStart=/usr/sbin/rngd -f
+ExecStart=@prefix@/sbin/rngd -f
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Ideally we'd substitute the value of `sbindir` here, but autoconf makes this a much more complicated task requiring additional make targets which I have not been able to get to work.

As such, this doesn't have complete compatibility-- if `$exec_prefix` is different to `$prefix`, or `$sbindir` is defined as something esoteric, things might not work.

Still, this covers the majority of cases.